### PR TITLE
Switches back to canonical display for #t and #f

### DIFF
--- a/lib/src/core/expressions.dart
+++ b/lib/src/core/expressions.dart
@@ -145,7 +145,7 @@ class Boolean extends SelfEvaluating implements Serializable<Boolean> {
   final bool value;
   const Boolean._internal(this.value);
   bool get isTruthy => value;
-  toString() => value ? "True" : "False";
+  toString() => value ? "#t" : "#f";
   bool toJS() => value;
   operator ==(other) => other is Boolean && value == other.value;
   int get hashCode => value.hashCode;


### PR DESCRIPTION
Resolves #1.

Wait for Cal-CS-61A-Staff/berkeley-cs61a#1423 to be merged before merging this.