### PR TITLE
Implements flag-based tracing

### DIFF
--- a/lib/gen/extra/extra_library.gen.dart
+++ b/lib/gen/extra/extra_library.gen.dart
@@ -14,6 +14,10 @@ abstract class _$ExtraLibraryMixin {
   void cancelListener(EventListener listener, Frame env);
   void cancelAll(SchemeSymbol id, Frame env);
   String stringAppend(List<Expression> exprs);
+  FlagTrace trace(Expression code, Frame env);
+  Visualization traceToVisualization(FlagTrace trace);
+  String serialize(Serializable expr);
+  Expression deserialize(String json);
   void importAll(Frame __env) {
     addPrimitive(__env, const SchemeSymbol("run-async"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)
@@ -76,5 +80,23 @@ abstract class _$ExtraLibraryMixin {
     addVariablePrimitive(__env, const SchemeSymbol('string-append'), (__exprs, __env) {
       return new SchemeString(this.stringAppend(__exprs));
     }, 0, -1);
+    addOperandPrimitive(__env, const SchemeSymbol("trace"), (__exprs, __env) {
+      return this.trace(__exprs[0], __env);
+    }, 1);
+    addPrimitive(__env, const SchemeSymbol('trace->visualization'), (__exprs, __env) {
+      if (__exprs[0] is! FlagTrace)
+        throw new SchemeException('Argument of invalid type passed to trace->visualization.');
+      return this.traceToVisualization(__exprs[0]);
+    }, 1);
+    addPrimitive(__env, const SchemeSymbol("serialize"), (__exprs, __env) {
+      if (__exprs[0] is! Serializable)
+        throw new SchemeException('Argument of invalid type passed to serialize.');
+      return new SchemeString(this.serialize(__exprs[0]));
+    }, 1);
+    addPrimitive(__env, const SchemeSymbol("deserialize"), (__exprs, __env) {
+      if (__exprs[0] is! SchemeString)
+        throw new SchemeException('Argument of invalid type passed to deserialize.');
+      return this.deserialize((__exprs[0] as SchemeString).value);
+    }, 1);
   }
 }

--- a/lib/src/core/expressions.dart
+++ b/lib/src/core/expressions.dart
@@ -27,6 +27,8 @@ abstract class Expression {
   bool get isNil => false;
   String get display => toString();
 
+  String toString() => '#[$runtimeType]';
+
   /// Should return the version of this object that can be passed to JS
   dynamic toJS() => this;
 

--- a/lib/src/core/procedures.dart
+++ b/lib/src/core/procedures.dart
@@ -45,6 +45,11 @@ abstract class UserDefinedProcedure extends Procedure {
 
   Frame makeCallFrame(PairOrEmpty arguments, Frame env);
 
+  Expression call(PairOrEmpty operands, Frame env) {
+    env.interpreter.triggerEvent(const SchemeSymbol('pre-user-call'), [], env);
+    return super.call(operands, env);
+  }
+
   Expression apply(PairOrEmpty arguments, Frame env) {
     Frame frame = makeCallFrame(arguments, env);
     if (name != null) frame.tag = name.toString();

--- a/lib/src/core/serialization.dart
+++ b/lib/src/core/serialization.dart
@@ -3,7 +3,6 @@ library cs61a_scheme.core.serialization;
 import 'dart:convert' show JSON;
 
 import 'expressions.dart';
-import 'logging.dart';
 import 'ui.dart';
 
 final Map<String, Serializable> deserializers = {
@@ -14,21 +13,14 @@ final Map<String, Serializable> deserializers = {
   'Anchor': new Anchor(),
 };
 
-abstract class Serializable<T extends Expression> {
+abstract class Serializable<T extends Expression> extends Expression {
   Map serialize();
   T deserialize(Map data);
 }
 
 class Serialization {
-  static Map serialize(Expression expr) {
-    if (expr is! Serializable) {
-      throw new SchemeException('$expr is not serializable');
-    }
-    return (expr as Serializable).serialize();
-  }
-
-  static String serializeToJson(Expression expr) {
-    return JSON.encode(serialize(expr));
+  static String serializeToJson(Serializable expr) {
+    return JSON.encode(expr.serialize());
   }
 
   static Expression deserialize(Map data) {

--- a/lib/src/core/ui.dart
+++ b/lib/src/core/ui.dart
@@ -52,7 +52,6 @@ abstract class UIElement extends SelfEvaluating implements Serializable {
   Map<Direction, Anchor> _anchors = {};
   Anchor anchor(Direction dir) => _anchors.putIfAbsent(dir, () => new Anchor());
   Iterable<Direction> get anchoredDirections => _anchors.keys;
-  toString() => "#[UIElement]";
   // If true, element should be invisible but take up the same amount of space.
   bool spacer = false;
   // Elements should call this when their contents update and they need to be
@@ -114,7 +113,6 @@ class TextElement extends UIElement {
 
 class Strike extends UIElement {
   Strike();
-  toString() => "#[Strike]";
 
   Map serialize() => finishSerialize({'type': 'Strike'});
   Strike deserialize(Map data) {

--- a/lib/src/core/utils.dart
+++ b/lib/src/core/utils.dart
@@ -58,6 +58,7 @@ Expression evalCallExpression(Pair expr, Frame env) {
     env.interpreter.triggerEvent(first, [rest], env);
     return result;
   }
+  env.interpreter.triggerEvent(const SchemeSymbol('call-expression'), [expr], env);
   return env.interpreter.implementation.evalProcedureCall(first, rest, env);
 }
 

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -6,6 +6,7 @@ import 'package:cs61a_scheme/cs61a_scheme.dart';
 
 import 'async.dart';
 import 'diagramming.dart';
+import 'flag_trace.dart';
 import 'operand_procedures.dart';
 import 'visualization.dart';
 
@@ -111,5 +112,23 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   @SchemeSymbol('string-append')
   String stringAppend(List<Expression> exprs) {
     return exprs.map((e) => e.display).join('');
+  }
+
+  @noeval
+  FlagTrace trace(Expression code, Frame env) {
+    return new FlagTraceBuilder(code, env).trace;
+  }
+
+  @SchemeSymbol('trace->visualization')
+  Visualization traceToVisualization(FlagTrace trace) {
+    return new Visualization.fromTrace(trace);
+  }
+
+  String serialize(Serializable expr) {
+    return Serialization.serializeToJson(expr);
+  }
+
+  Expression deserialize(String json) {
+    return Serialization.deserializeFromJson(json);
   }
 }

--- a/lib/src/extra/flag_trace.dart
+++ b/lib/src/extra/flag_trace.dart
@@ -103,7 +103,7 @@ class FlagTraceBuilder {
     inter.stopListening(const SchemeSymbol('define'), _step);
     inter.stopListening(const SchemeSymbol('set!'), _step);
     inter.stopListening(const SchemeSymbol('pair-mutation'), _step);
-    inter.stopListening(const SchemeSymbol('new-frame'), _step);
+    inter.stopListening(const SchemeSymbol('new-frame'), _frameStep);
     inter.stopListening(const SchemeSymbol('pre-user-call'), _userCall);
     inter.stopListening(const SchemeSymbol('call-expression'), _callExpr);
     inter.stopListening(const SchemeSymbol('return'), _returnStep);

--- a/lib/src/extra/flag_trace.dart
+++ b/lib/src/extra/flag_trace.dart
@@ -10,7 +10,7 @@ import 'package:cs61a_scheme/cs61a_scheme.dart';
 
 import 'diagramming.dart';
 
-class FlagTrace {
+class FlagTrace extends SelfEvaluating implements Serializable<FlagTrace> {
   List<FlagStep> steps = [];
   String code;
   String language;
@@ -30,7 +30,7 @@ class FlagTrace {
   }
 }
 
-class FlagStep extends SelfEvaluating with Serializable<FlagStep> {
+class FlagStep extends SelfEvaluating implements Serializable<FlagStep> {
   Diagram diagram;
   List<Flag> flags;
   FlagStep(this.diagram, this.flags);
@@ -45,7 +45,7 @@ class FlagStep extends SelfEvaluating with Serializable<FlagStep> {
       data['flags'].map(Serialization.deserialize).toList());
 }
 
-class Flag extends SelfEvaluating with Serializable<Flag> {
+class Flag extends SelfEvaluating implements Serializable<Flag> {
   String callExpression;
   List<Flag> operands = [];
   int frameId;
@@ -65,5 +65,131 @@ class Flag extends SelfEvaluating with Serializable<Flag> {
     flag.operands = data['operands'].map(Serialization.deserialize).toList();
     flag.body = data['body'].map(Serialization.deserialize).toList();
     return flag;
+  }
+
+  Flag clone() => new Flag(callExpression, frameId)
+    ..operands = operands.map((f) => f.clone()).toList()
+    ..body = body.map((f) => f.clone()).toList();
+}
+
+class FlagTraceBuilder {
+  FlagTrace trace;
+  Map<Frame, Expression> _frameReturnValues = new Map.identity();
+  List<Flag> _sourceFlags = [];
+  // Boolean should true if adding operands, false if adding to body.
+  List<Pair<Flag, Boolean>> _flagStack = [];
+  String _potentialCallExpr = null;
+
+  FlagTraceBuilder(Expression code, Frame env) {
+    Interpreter inter = env.interpreter;
+
+    trace = new FlagTrace('$code');
+
+    inter.listenFor(const SchemeSymbol('define'), _step);
+    inter.listenFor(const SchemeSymbol('set!'), _step);
+    inter.listenFor(const SchemeSymbol('pair-mutation'), _step);
+    inter.listenFor(const SchemeSymbol('new-frame'), _frameStep);
+    inter.listenFor(const SchemeSymbol('pre-user-call'), _userCall);
+    inter.listenFor(const SchemeSymbol('call-expression'), _callExpr);
+    inter.listenFor(const SchemeSymbol('return'), _returnStep);
+
+    bool oldStatus = env.interpreter.tailCallOptimized;
+    env.interpreter.tailCallOptimized = false;
+    _step([], env);
+    schemeEval(code, env);
+    _step([], env);
+    env.interpreter.tailCallOptimized = oldStatus;
+
+    inter.stopListening(const SchemeSymbol('define'), _step);
+    inter.stopListening(const SchemeSymbol('set!'), _step);
+    inter.stopListening(const SchemeSymbol('pair-mutation'), _step);
+    inter.stopListening(const SchemeSymbol('new-frame'), _step);
+    inter.stopListening(const SchemeSymbol('pre-user-call'), _userCall);
+    inter.stopListening(const SchemeSymbol('call-expression'), _callExpr);
+    inter.stopListening(const SchemeSymbol('return'), _returnStep);
+  }
+
+  Undefined _step(List<Expression> exprs, Frame env) {
+    _addFrames(env);
+    Diagram diagram = _makeDiagram(env);
+    trace.steps.add(new FlagStep(diagram, _cloneSource()));
+    return undefined;
+  }
+
+  Undefined _returnStep(List<Expression> exprs, Frame env) {
+    if (exprs.length != 1) {
+      throw new SchemeException("Invalid event $exprs trigged during tracing");
+    } else if (_flagStack.isEmpty) {
+      throw new SchemeException("Frame returned without flag on stack");
+    }
+    _flagStack.removeLast();
+    Expression returnValue = exprs[0];
+    _addFrames(env, returnValue);
+    Diagram diagram = _makeDiagram(env);
+    trace.steps.add(new FlagStep(diagram, _cloneSource()));
+    return undefined;
+  }
+
+  Undefined _frameStep(List<Expression> exprs, Frame env) {
+    if (_flagStack.isEmpty) {
+      throw new SchemeException("New frame created without flag on stack");
+    }
+    _flagStack.last.first.frameId = env.id;
+    _flagStack.last.second = schemeFalse;
+    _addFrames(env);
+    Diagram diagram = _makeDiagram(env);
+    trace.steps.add(new FlagStep(diagram, _cloneSource()));
+    return undefined;
+  }
+
+  Undefined _callExpr(List<Expression> exprs, Frame env) {
+    if (exprs.length != 1) {
+      throw new SchemeException("Invalid event $exprs trigged during tracing");
+    }
+    _potentialCallExpr = exprs[0].toString();
+    return undefined;
+  }
+
+  Undefined _userCall(List<Expression> exprs, Frame env) {
+    Flag flag = new Flag(_potentialCallExpr, null);
+    if (_flagStack.isEmpty) {
+      _sourceFlags.add(flag);
+    } else {
+      Flag container = _flagStack.last.first;
+      bool inOperands = _flagStack.last.second.isTruthy;
+      if (inOperands) {
+        container.operands.add(flag);
+      } else {
+        container.body.add(flag);
+      }
+    }
+    _flagStack.add(new Pair(flag, schemeTrue));
+    return undefined;
+  }
+
+  List<Flag> _cloneSource() => _sourceFlags.map((f) => f.clone()).toList();
+
+  void _addFrames(Frame myEnv, [Expression returnValue = null]) {
+    if (myEnv.tag == '#imported') return;
+    if (_frameReturnValues.containsKey(myEnv)) {
+      _frameReturnValues[myEnv] = returnValue;
+      return;
+    }
+    _frameReturnValues[myEnv] = returnValue;
+    for (SchemeSymbol binding in myEnv.bindings.keys) {
+      Expression value = myEnv.bindings[binding];
+      if (value is LambdaProcedure) {
+        _addFrames(value.env);
+      }
+    }
+    if (myEnv.parent != null) _addFrames(myEnv.parent);
+  }
+
+  Diagram _makeDiagram(Frame active) {
+    List<Frame> frames = _frameReturnValues.keys.toList()..sort((a, b) => a.id - b.id);
+    List<Pair<Frame, Expression>> passing = frames.map((frame) {
+      return new Pair(frame, _frameReturnValues[frame]);
+    }).toList();
+    return new Diagram.allFrames(passing, active);
   }
 }

--- a/lib/src/extra/visualization.dart
+++ b/lib/src/extra/visualization.dart
@@ -5,6 +5,7 @@ import 'dart:async';
 import 'package:cs61a_scheme/cs61a_scheme.dart';
 
 import 'diagramming.dart';
+import 'flag_trace.dart';
 
 class Button extends UIElement {
   void Function() click;
@@ -51,6 +52,16 @@ class Visualization extends UIElement {
     inter.stopListening(const SchemeSymbol('pair-mutation'), _makeVisualizeStep);
     inter.stopListening(const SchemeSymbol('new-frame'), _makeVisualizeStep);
     inter.stopListening(const SchemeSymbol('return'), _makeVisualizeReturnStep);
+
+    _init();
+  }
+
+  Visualization.fromTrace(FlagTrace trace) {
+    diagrams = trace.steps.map((step) => step.diagram).toList();
+    _init();
+  }
+
+  _init() {
     bool animating = false;
     goto(int index, [bool keepAnimating = false]) {
       if (!keepAnimating) animating = false;


### PR DESCRIPTION
FlagTraceBuilder can now be used to generate FlagTraces. FlagTraces can't be rendered directly by the interpreter; they're designed to be serialized and sent to Semaphore.

Adds the following built-in Scheme procedures:
- `trace`: Pass in code similar to `visualize`. Returns a FlagTrace.
- `trace->visualization`: Converts a trace to a visualization, which can be rendered in the normal scheme.cs61a.org interpreter.
- `serialize`: Returns a serialized version of the expression.
- `deserialize`: Rebuilds an expression based on the serialization.

Semaphore should be able to take a serialized FlagTrace and render it, once it is implemented.