### PR TITLE
Fix errors on Dart 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-# Files and directories created by pub
+# Files and directories created by pub/tools
 .packages
 .pub/
 build/
+.dart_tool/
 # Remove the following pattern if you wish to check in your lock file
 pubspec.lock
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,7 @@ script:
 - pub run test $NO_IMPL
 - pub run grinder check
 - dartfmt -n --set-exit-if-changed .
-- |
-  if [ "${TRAVIS_DART_VERSION}" = "dev" ]
-  then
-    echo "Skipping dartanalyzer on dev (since APIs have changed)"
-  else
-    dartanalyzer --fatal-warnings --strong .
-  fi
+- dartanalyzer --fatal-warnings --strong .
 - pub run dependency_validator
 before_deploy:
 - eval "$(ssh-agent -s)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ for examples.
 Each `SchemeLibrary` is supported by a generated mixin that is responsible for
 loading all built-ins and doing various type checks and conversions. Whenever
 you create a new `SchemeLibrary`, make sure to add it to the list of libraries
-in `tool/grind.dart`.
+in `tool/grind.dart`. You also need to annotate the class with `@schemelib`.
 
 ### Adding Built-Ins
 

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -11,7 +11,7 @@ String generateImportMixin(String sourceCode) {
   for (CompilationUnitMember decl in ast.declarations) {
     if (decl is ClassDeclaration) {
       for (Annotation annotation in decl.metadata) {
-        if (annotation.name.toSource() == "library") {
+        if (annotation.name.toSource() == "schemelib") {
           return _buildMixin(decl);
         }
       }

--- a/lib/src/core/expressions.dart
+++ b/lib/src/core/expressions.dart
@@ -1,6 +1,6 @@
 library cs61a_scheme.core.expressions;
 
-import 'dart:collection' show IterableMixin;
+import 'dart:collection' show IterableMixin, IterableBase;
 import 'dart:convert' show JSON;
 
 import 'package:quiver_hashcode/hashcode.dart';
@@ -184,49 +184,29 @@ abstract class PairOrEmpty extends Expression implements Iterable<Expression> {
 ///
 /// This can't use [IterableMixin] because we need it to have a constant
 /// constructor, so we have to implement all the [Iterable] methods ourselves.
-class _EmptyList extends SelfEvaluating implements PairOrEmpty {
+class _EmptyList extends IterableBase<Expression>
+    implements SelfEvaluating, PairOrEmpty {
   final inlineUI = true;
-  const _EmptyList._internal();
+  const _EmptyList();
   bool get wellFormed => true;
   @deprecated
   bool isWellFormedList() => true;
   bool get isNil => true;
   toString() => "()";
+  get iterator => new _NilIterator();
 
   num get lengthOrCycle => 0;
 
-  get first => throw new StateError("empty list");
-  final isEmpty = true;
-  final isNotEmpty = false;
-  get iterator => new _NilIterator();
-  get last => throw new StateError("empty list");
-  final int length = 0;
-  get single => throw new StateError("empty list");
-  any(f) => false;
-  contains(e) => false;
-  every(f) => true;
-  elementAt(f) => throw new StateError("empty list");
-  expand<T>(f) => <T>[];
-  firstWhere(test, {orElse = null}) =>
-      orElse == null ? throw new StateError("empty list") : orElse();
-  fold<T>(init, combine) => init;
-  forEach(f) => null;
-  join([sep]) => "";
-  lastWhere(test, {orElse = null}) => firstWhere(test, orElse: orElse);
-  List<T> map<T>(Function fn) => [];
-  reduce(comb) => throw new StateError("empty list");
-  singleWhere(test) => throw new StateError("empty list");
-  skip(c) => this;
-  skipWhile(test) => this;
-  take(c) => this;
-  takeWhile(c) => this;
-  toList({bool growable: false}) => growable ? [] : new List(0);
-  toSet() => new Set();
-  where(t) => this;
+  get display => toString();
+  draw(DiagramInterface diagram) => new TextElement('()');
+  evaluate(Frame env) => this;
+  get isTruthy => true;
+  get pair => this as Pair;
+  toJS() => this;
 }
 
 /// The empty Scheme list.
-const nil = const _EmptyList._internal();
+const nil = const _EmptyList();
 
 /// A Scheme pair.
 ///

--- a/lib/src/core/numbers.dart
+++ b/lib/src/core/numbers.dart
@@ -1,6 +1,7 @@
 library cs61a_scheme.core.numbers;
 
-import 'package:rational/bigint.dart';
+/// Prefixed to avoid shadowing BigInt in Dart 2 until switch.
+import 'package:rational/bigint.dart' as lib;
 
 import 'expressions.dart';
 import 'logging.dart';
@@ -34,7 +35,7 @@ abstract class Number extends SelfEvaluating {
   /// Note that strings like `"1.0"` will yield an [Integer], not a [Double].
   factory Number.fromString(String numString) {
     try {
-      return new Integer.fromBigInt(BigInt.parse(numString));
+      return new Integer.fromBigInt(lib.BigInt.parse(numString));
     } catch (e) {
       return new Number.fromNum(num.parse(numString));
     }
@@ -88,15 +89,15 @@ abstract class Number extends SelfEvaluating {
 /// Once updated for Dart 2, the [BigInt] class from the rational library should
 /// be replaced with the built-in class.
 class Integer extends Number implements Serializable<Integer> {
-  BigInt value;
+  lib.BigInt value;
 
   Integer.fromBigInt(this.value);
 
   factory Integer(int value) =>
-      new Integer.fromBigInt(new BigInt.fromJsInt(value));
+      new Integer.fromBigInt(new lib.BigInt.fromJsInt(value));
 
   Integer deserialize(Map data) =>
-      new Integer.fromBigInt(BigInt.parse(data['value']));
+      new Integer.fromBigInt(lib.BigInt.parse(data['value']));
 
   Map serialize() => {'type': 'Integer', 'value': value.toString()};
 

--- a/lib/src/core/scheme_library.dart
+++ b/lib/src/core/scheme_library.dart
@@ -43,7 +43,7 @@ abstract class SchemeLibrary {
 ///
 /// When present, all methods within the class that do not start with "import"
 /// or an underscore will be added as built-in procedures.
-const _Library library = const _Library();
+const _Library schemelib = const _Library();
 
 class _Library {
   const _Library();

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -14,7 +14,7 @@ part 'standard_library.g.dart';
 /// Note: When the signatures (including any annotations) of any of these methods
 /// change, make sure to `pub run grinder` to rebuild the mixin (which registers
 /// the primitives and performs type checking on arguments).
-@library
+@schemelib
 class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   Expression apply(Procedure procedure, PairOrEmpty args, Frame env) {
     return schemeApply(procedure, args, env);

--- a/lib/src/core/ui.dart
+++ b/lib/src/core/ui.dart
@@ -210,4 +210,4 @@ abstract class DiagramInterface extends UIElement {
   UIElement pointTo(Expression expression, [int parentRow]);
 }
 
-typedef void Renderer(UIElement);
+typedef void Renderer(UIElement element);

--- a/lib/src/extra/async.dart
+++ b/lib/src/extra/async.dart
@@ -59,10 +59,10 @@ class AsyncLambdaProcedure extends LambdaProcedure {
   }
 }
 
-class EventListener extends SelfEvaluating {
+class SchemeEventListener extends SelfEvaluating {
   final SchemeSymbol id;
   final SchemePrimitive callback;
-  EventListener(this.id, this.callback);
+  SchemeEventListener(this.id, this.callback);
 
   toString() => '#[event-listener:$id]';
 

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -15,7 +15,7 @@ part 'extra_library.g.dart';
 /// Note: When the signatures (including any annotations) of any of theses methods
 /// change, make sure to `pub run grinder` to rebuild the mixin (which registers
 /// the primitives and performs type checking on arguments).
-@library
+@schemelib
 class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   ExtraLibrary() {
     initTraceDeserializers();
@@ -92,7 +92,7 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   }
 
   @SchemeSymbol('listen-for')
-  EventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env) {
+  SchemeEventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env) {
     var callback = (List<Expression> exprs, Frame env) {
       try {
         schemeApply(onEvent, new PairOrEmpty.fromIterable(exprs), env);
@@ -106,11 +106,11 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
       }
     };
     env.interpreter.listenFor(id, callback);
-    return new EventListener(id, callback);
+    return new SchemeEventListener(id, callback);
   }
 
   @SchemeSymbol('cancel-listener')
-  void cancelListener(EventListener listener, Frame env) {
+  void cancelListener(SchemeEventListener listener, Frame env) {
     env.interpreter.stopListening(listener.id, listener.callback);
   }
 

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -10,8 +10,8 @@ abstract class _$ExtraLibraryMixin {
   Visualization visualize(Expression code, Frame env);
   PairOrEmpty bindings(Frame env);
   void triggerEvent(List<Expression> exprs, Frame env);
-  EventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env);
-  void cancelListener(EventListener listener, Frame env);
+  SchemeEventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env);
+  void cancelListener(SchemeEventListener listener, Frame env);
   void cancelAll(SchemeSymbol id, Frame env);
   String stringAppend(List<Expression> exprs);
   FlagTrace trace(Expression code, Frame env);
@@ -71,7 +71,7 @@ abstract class _$ExtraLibraryMixin {
     }, 2);
     addPrimitive(__env, const SchemeSymbol('cancel-listener'),
         (__exprs, __env) {
-      if (__exprs[0] is! EventListener)
+      if (__exprs[0] is! SchemeEventListener)
         throw new SchemeException(
             'Argument of invalid type passed to cancel-listener.');
       var __value = undefined;

--- a/lib/src/extra/logic_library.dart
+++ b/lib/src/extra/logic_library.dart
@@ -11,7 +11,7 @@ part 'logic_library.g.dart';
 /// Note: When the signatures (including any annotations) of any of theses methods
 /// change, make sure to `pub run grinder` to rebuild the mixin (which registers
 /// the primitives and performs type checking on arguments).
-@library
+@schemelib
 class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
   Map<Frame, List<logic.Fact>> facts = new Map.identity();
 

--- a/lib/src/web/turtle_library.dart
+++ b/lib/src/web/turtle_library.dart
@@ -12,7 +12,7 @@ part 'turtle_library.g.dart';
 /// Note: When the signatures (including any annotations) of any of this methods
 /// change, make sure to `pub run grinder` to rebuild the mixin (which registers
 /// the primitives and performs type checking on arguments).
-@library
+@schemelib
 class TurtleLibrary extends SchemeLibrary with _$TurtleLibraryMixin {
   Turtle turtle;
 

--- a/lib/src/web/web_library.dart
+++ b/lib/src/web/web_library.dart
@@ -16,7 +16,7 @@ part 'web_library.g.dart';
 /// Note: When the signatures (including any annotations) of any of this methods
 /// change, make sure to `pub run grinder` to rebuild the mixin (which registers
 /// the primitives and performs type checking on arguments).
-@library
+@schemelib
 class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
   final html.Element renderContainer;
   final JsObject jsPlumb;


### PR DESCRIPTION
Tested with Dart 2.0.0-dev.45.0.

At this point, everything still works in Dart 1. Once Dart 2 is stable, I'll change the deprecated members and increase the minimum SDK to 2.0.

Travis should now run the analyzer on dev in addition to stable.