### PR TITLE
Use constants from dart2_constant

### DIFF
--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -1,6 +1,6 @@
 library builder;
 
-import 'dart:convert' show JSON;
+import 'package:dart2_constant/convert.dart' show json;
 
 import 'package:analyzer/analyzer.dart';
 
@@ -55,7 +55,7 @@ String _buildAbstract(MethodDeclaration method) {
 bool needsTurtle = false;
 
 String _buildPrimitive(MethodDeclaration method) {
-  String name = JSON.encode(method.name.toSource().toLowerCase());
+  String name = json.encode(method.name.toSource().toLowerCase());
   bool setName = false;
   List<String> extraNames = [];
   bool variable = false;

--- a/lib/src/core/expressions.dart
+++ b/lib/src/core/expressions.dart
@@ -1,8 +1,9 @@
 library cs61a_scheme.core.expressions;
 
 import 'dart:collection' show IterableMixin, IterableBase;
-import 'dart:convert' show JSON;
 
+import 'package:dart2_constant/convert.dart' show json;
+import 'package:dart2_constant/core.dart' as core;
 import 'package:quiver_hashcode/hashcode.dart';
 
 import 'interpreter.dart';
@@ -120,7 +121,7 @@ class SchemeString extends SelfEvaluating
   final inlineUI = true;
   final String value;
   const SchemeString(this.value);
-  toString() => JSON.encode(value);
+  toString() => json.encode(value);
   get display => value;
   operator ==(other) => other is SchemeString && value == other.value;
   int get hashCode => hash2("SchemeString", value);
@@ -240,7 +241,7 @@ class Pair<A extends Expression, B extends Expression> extends Expression
       slow = slow.pair.second;
       fast = fast.pair.second.pair.second;
       length += 2;
-      if (identical(slow, fast)) return double.INFINITY;
+      if (identical(slow, fast)) return core.double.infinity;
     }
     if (!wellFormed) throw new SchemeException("Malformed list");
     return length + (fast is Pair ? 1 : 0);

--- a/lib/src/core/reader.dart
+++ b/lib/src/core/reader.dart
@@ -1,6 +1,6 @@
 library cs61a_scheme.reader;
 
-import 'dart:convert' show JSON;
+import 'package:dart2_constant/convert.dart' show json;
 import 'dart:math' show min;
 
 import 'expressions.dart';
@@ -118,7 +118,7 @@ Iterable<Expression> tokenizeLine(String line) sync* {
         }
       }
     } else if (_stringDelims.contains(text[0])) {
-      yield new SchemeString(JSON.decode(text));
+      yield new SchemeString(json.decode(text));
     } else {
       throw new FormatException("warning: invalid token: $text in $line");
     }

--- a/lib/src/core/serialization.dart
+++ b/lib/src/core/serialization.dart
@@ -1,6 +1,6 @@
 library cs61a_scheme.core.serialization;
 
-import 'dart:convert' show JSON;
+import 'package:dart2_constant/convert.dart' show json;
 
 import 'expressions.dart';
 import 'numbers.dart';
@@ -27,7 +27,7 @@ abstract class Serializable<T extends Expression> extends Expression {
 
 class Serialization {
   static String serializeToJson(Serializable expr) {
-    return JSON.encode(expr.serialize());
+    return json.encode(expr.serialize());
   }
 
   static Expression deserialize(Map data) {
@@ -39,7 +39,7 @@ class Serialization {
     return deserializers[data['type']].deserialize(data);
   }
 
-  static Expression deserializeFromJson(String json) {
-    return deserialize(JSON.decode(json));
+  static Expression deserializeFromJson(String data) {
+    return deserialize(json.decode(data));
   }
 }

--- a/lib/src/web/turtle.dart
+++ b/lib/src/web/turtle.dart
@@ -1,7 +1,8 @@
 library cs61a_scheme.web_turtle;
 
 import 'dart:html';
-import 'dart:math' as Math;
+import 'dart:math' show cos, sin;
+import 'package:dart2_constant/math.dart' show pi;
 
 import 'package:cs61a_scheme/cs61a_scheme.dart';
 
@@ -109,7 +110,7 @@ class Turtle {
     context.setStrokeColorRgb(0, 0, 0, 0);
   }
 
-  num get realHeading => (heading - 90) / 180 * Math.PI;
+  num get realHeading => (heading - 90) / 180 * pi;
   num get realX => x + (gridWidth / 2);
   num get realY => (gridHeight / 2) - y;
   void set realX(num realX) => x = realX - (gridWidth / 2);
@@ -167,14 +168,14 @@ class Turtle {
   }
 
   static List<num> getPointTo(num ang, num forward, num x, num y) {
-    return [x + forward * Math.cos(ang), y + forward * Math.sin(ang)];
+    return [x + forward * cos(ang), y + forward * sin(ang)];
   }
 
   point(n) => getPointTo(realHeading, n, realX, realY);
 
   circle(num radius, [num arc = 360]) {
     num rad = radius.abs();
-    var cpoint = getPointTo(realHeading - Math.PI / 2, radius, realX, realY);
+    var cpoint = getPointTo(realHeading - pi / 2, radius, realX, realY);
     num cx = cpoint[0];
     num cy = cpoint[1];
     num initX = realX;
@@ -184,9 +185,9 @@ class Turtle {
     bool reverse = arc < 0;
     arc = arc.abs();
 
-    num circleStart = realHeading + Math.PI / 2;
+    num circleStart = realHeading + pi / 2;
     for (num i = 0; i <= arc; i += 60 / rad) {
-      num radians = Math.PI * i / 180;
+      num radians = pi * i / 180;
       if (reverse) radians = -radians;
       var point = getPointTo(circleStart - radians, radius, cx, cy);
       drawLine(point, true);

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -1,7 +1,7 @@
 library web_repl;
 
 import 'dart:async';
-import 'dart:convert' show JSON;
+import 'package:dart2_constant/convert.dart' show json;
 import 'dart:html';
 import 'dart:js';
 
@@ -22,7 +22,7 @@ class Repl {
 
   Repl(this.interpreter, Element parent) {
     if (window.localStorage.containsKey('#repl-history')) {
-      var decoded = JSON.decode(window.localStorage['#repl-history']);
+      var decoded = json.decode(window.localStorage['#repl-history']);
       if (decoded is List) history = decoded.map((item) => '$item').toList();
     }
     addPrimitives();
@@ -166,7 +166,7 @@ class Repl {
     if (history.isNotEmpty && code == history[0]) return;
     history.insert(0, code);
     var subset = history.take(100).toList();
-    window.localStorage['#repl-history'] = JSON.encode(subset);
+    window.localStorage['#repl-history'] = json.encode(subset);
   }
 
   historyUp() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   analyzer: ^0.30.0+2
+  dart2_constant: ^1.0.1
   quiver_hashcode: ^1.0.0
   rational: ^0.1.11
 


### PR DESCRIPTION
Dart 2 will change all of the standard library constants from `SCREAMING_CAPS` to `camelCase`.

This switches all of our constant references to use the `dart2_constant` package, which uses the old constants on Dart 1 and the new ones on Dart 2. Once this project switches fully to Dart 2, we can replace these constants with the built-in `camelCase` ones.