### PR TITLE
Adds MarkdownElement to the rendering framework

### DIFF
--- a/lib/src/core/serialization.dart
+++ b/lib/src/core/serialization.dart
@@ -15,6 +15,7 @@ final Map<String, Serializable> deserializers = {
   'SchemeString': const SchemeString('x'),
   'Anchor': new Anchor.withId(-1),
   'TextElement': new TextElement(""),
+  'MarkdownElement': new MarkdownElement(null),
   'Strike': new Strike(),
   'Block': new Block.pair(null),
   'BlockGrid': new BlockGrid([[]])

--- a/lib/src/core/ui.dart
+++ b/lib/src/core/ui.dart
@@ -6,7 +6,9 @@ import 'dart:async';
 
 import 'expressions.dart';
 import 'logging.dart';
+import 'procedures.dart' show Procedure;
 import 'serialization.dart';
+import 'utils.dart' show schemeApply;
 
 class Direction extends SelfEvaluating {
   final String _id;
@@ -103,7 +105,7 @@ class Anchor extends UIElement {
 class TextElement extends UIElement {
   final String text;
   TextElement(this.text);
-  toString() => "#[TextElement:$text]";
+  toString() => text;
 
   Map serialize() => finishSerialize({
         'type': 'TextElement',
@@ -111,6 +113,28 @@ class TextElement extends UIElement {
       });
   TextElement deserialize(Map data) {
     return new TextElement(data['text'])..finishDeserialize(data);
+  }
+}
+
+class MarkdownElement extends TextElement {
+  bool inline;
+
+  Frame env;
+
+  MarkdownElement(String text, {this.inline: true, this.env}) : super(text);
+
+  void runLink(String name) {
+    if (env == null) return;
+    var proc = env.lookup(new SchemeSymbol.runtime(name));
+    if (proc is Procedure) {
+      schemeApply(proc, nil, env);
+    }
+  }
+
+  Map serialize() => {'type': 'MarkdownElement', 'text': text};
+
+  MarkdownElement deserialize(Map data) {
+    return new MarkdownElement(data['text']);
   }
 }
 

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -141,4 +141,9 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   Expression deserialize(String json) {
     return Serialization.deserializeFromJson(json);
   }
+
+  MarkdownElement formatted(List<Expression> expressions, Frame env) {
+    String text = expressions.map((expr) => expr.display).join('');
+    return new MarkdownElement(text, inline: true, env: env);
+  }
 }

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -18,6 +18,7 @@ abstract class _$ExtraLibraryMixin {
   Visualization traceToVisualization(FlagTrace trace);
   String serialize(Serializable expr);
   Expression deserialize(String json);
+  MarkdownElement formatted(List<Expression> expressions, Frame env);
   void importAll(Frame __env) {
     addPrimitive(__env, const SchemeSymbol("run-async"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)
@@ -112,5 +113,9 @@ abstract class _$ExtraLibraryMixin {
             'Argument of invalid type passed to deserialize.');
       return this.deserialize((__exprs[0] as SchemeString).value);
     }, 1);
+    addVariablePrimitive(__env, const SchemeSymbol("formatted"),
+        (__exprs, __env) {
+      return this.formatted(__exprs, __env);
+    }, 0, -1);
   }
 }

--- a/lib/src/extra/logic_library.dart
+++ b/lib/src/extra/logic_library.dart
@@ -23,6 +23,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
 
     // Only import the loader to start. Calling logic imports the rest.
     env.define(sym, child.bindings[sym]);
+    env.hidden[sym] = true;
   }
 
   @SchemeSymbol('logic')

--- a/lib/styles/_diagram.scss
+++ b/lib/styles/_diagram.scss
@@ -4,6 +4,19 @@
   
   @include render;
 
+  .markdown {
+    @include text;
+    .button {
+      font-size: 0.7em;
+      padding: 0.15em 0.45em;
+      margin: 0.05em;
+    }
+    code {
+      font-family: inherit;
+      font-size: inherit;
+    }
+  }
+
   .button {
     font-size: 0.92em;
     padding: 0.25em 0.375em;

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -47,14 +47,9 @@ class Repl {
     container.append(status);
     buildNewInput();
     interpreter.logger = (Expression logging, [bool newline = true]) {
-      if (logging is UIElement) {
-        var renderBox = new DivElement()..classes = ['render'];
-        activeLoggingArea.append(renderBox);
-        var renderer = new HtmlRenderer(renderBox, context['jsPlumb']);
-        renderer.render(logging);
-      } else {
-        logText(logging.toString() + (newline ? '\n' : ''));
-      }
+      var box = new SpanElement();
+      activeLoggingArea.append(box);
+      logInto(box, logging, newline);
     };
     interpreter.logError = (e) {
       var errorElement = new SpanElement()
@@ -123,18 +118,10 @@ class Repl {
       try {
         Expression expr = schemeRead(tokens, interpreter.impl);
         result = schemeEval(expr, interpreter.globalEnv);
-        if (result is AsyncExpression) {
-          var box = new SpanElement()
-            ..text = '$result\n'
-            ..classes = ['repl-async'];
-          loggingArea.append(box);
-          var awaited = await result.future;
-          box.classes = ['repl-log'];
-          logInto(box, awaited is Undefined ? null : result);
-        } else if (result is! Undefined) {
+        if (result is! Undefined) {
           var box = new SpanElement();
           loggingArea.append(box);
-          logInto(box, result, true);
+          await logInto(box, result, true);
         }
       } on SchemeException catch (e) {
         loggingArea.append(new SpanElement()
@@ -272,7 +259,17 @@ class Repl {
   }
 
   logInto(Element element, Expression logging, [bool newline = true]) {
-    if (logging == null) {
+    if (logging is AsyncExpression) {
+      var box = new SpanElement()
+        ..text = '$logging\n'
+        ..classes = ['repl-async'];
+      element.append(box);
+      return logging.future.then((Expression expr) {
+        box.classes = ['repl-log'];
+        logInto(box, expr is Undefined ? null : expr);
+        return null;
+      });
+    } else if (logging == null) {
       element.text = '';
     } else if (logging is UIElement) {
       element.classes.add('render');
@@ -293,6 +290,7 @@ class Repl {
       element.text = logging.toString() + (newline ? '\n' : '');
     }
     container.scrollTop = container.scrollHeight;
+    return null;
   }
 
   logElement(Element element) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   analyzer: ^0.30.0+2
   dart2_constant: ^1.0.1
+  markdown: ^1.1.1
   quiver_hashcode: ^1.0.0
   rational: ^0.1.11
 

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -33,7 +33,6 @@ body {
   z-index:200;
   font-size: 0.92em;
   font-family:$font-stack;
-  pointer-events: none;
   @include text;
 }
 
@@ -89,7 +88,7 @@ body {
   @include background;
   @include text;
 
-  a {
+  a:not(.button){
     @include link;
   }
 

--- a/web/main.dart
+++ b/web/main.dart
@@ -6,56 +6,45 @@ import 'package:cs61a_scheme_impl/impl.dart' show StaffProjectImplementation;
 
 import 'package:cs61a_scheme/web_repl.dart';
 
-const String motd = "<strong>61A Scheme Web Interpreter 2.0.0-beta</strong>"
-    "                         "
-    """<small><a id='github' target='_blank'>View Source on GitHub</a></small>
-********************************************************************************
-<strong>Diagramming</strong>
-(draw &lt;any list>) to create a box-and-pointer diagram
-(autodraw) to start drawing diagrams for any returned list
-(visualize &lt;some code>) to create an environment diagram
+const String motd = "**61A Scheme Web Interpreter 2.0.0-beta**"
+    "                         <small>"
+    "[View Source on GitHub](https://github.com/Cal-CS-61A-Staff/dart_scheme)"
+    """</small>
+--------------------------------------------------------------------------------
+**Diagramming**
+`(draw some-pair)` to create a box-and-pointer diagram [Try It](:try-draw)
+`(autodraw)` to start drawing diagrams for any returned list [Try It](:try-ad)
+`(visualize some-code)` to create an environment diagram [Try It](:try-viz)
 
-<strong>Other Useful Commands</strong>
-(clear) to clear all output on the screen
-(theme 'id) to change the interpreter's theme
-    default, solarized, monochrome, monochrome-dark, and go-bears available
-(bindings) returns a list of all names bound in the current environment
-(import 'scm/apps/chess) to play a game of chess (missing some features)
+**Other Useful Commands**
+`(clear)` to clear all output on the screen
+`(theme 'id)` to change the interpreter's theme
+[default](:try-default) [solarized](:try-solarized) """
+    "[monochrome](:try-monochrome) [monochrome-dark](:try-monochrome-dark) "
+    """[go-bears](:try-go-bears)
+`(bindings)` returns a list of all names bound in the current environment
+`(import 'scm/apps/chess)` to play a game of chess (missing some features) """
+    """[Try It](:try-chess)
 
-<strong>Keyboard Shortcuts</strong>
+**Keyboard Shortcuts**
 Up/Down to scroll through history (Hold Ctrl to scroll past multiline entry)
 Shift+Enter to add missing parens and run the current input
 
-<i>Looking for the old version? """
-    """<a id='legacy-interpreter' target="_blank">Interpreter</a> &mdash; """
-    """<a id='legacy-editor' target="_blank">Editor</a></i>
+*Looking for the old version? """
+    """[Interpreter](https://scheme-legacy.apps.cs61a.org) &mdash; """
+    """[Editor](https://scheme-legacy-apps.cs61a.org/editor.html)*
 
 """;
 
 main() async {
   var inter = new Interpreter(new StaffProjectImplementation());
   var normals = inter.globalEnv.bindings.keys.toSet();
-  inter.importLibrary(new ExtraLibrary());
-  inter.importLibrary(new LogicLibrary());
+  var extra = new ExtraLibrary();
+  var logic = new LogicLibrary();
   var diagramBox = querySelector('#diagram');
   String css = await HttpRequest.getString('assets/style.css');
   var style = querySelector('#theme');
   var web = new WebLibrary(diagramBox, context['jsPlumb'], css, style);
-  inter.importLibrary(web);
-  var specials = inter.globalEnv.bindings.keys.toSet().difference(normals);
-  inter.importLibrary(new TurtleLibrary(querySelector('canvas'), inter));
-  var turtles = inter.globalEnv.bindings.keys
-      .toSet()
-      .difference(specials)
-      .difference(normals);
-  context.callMethod('hljsRegister', [
-    new JsObject.jsify({
-      'builtin-normal':
-          normals.union(inter.specialForms.keys.toSet()).join(' '),
-      'builtin-special': specials.join(' '),
-      'builtin-turtle': turtles.join(' ')
-    })
-  ]);
   if (window.localStorage.containsKey('#scheme-theme')) {
     try {
       var expr = Serialization
@@ -71,13 +60,48 @@ main() async {
   onThemeChange.listen((Theme theme) {
     window.localStorage['#scheme-theme'] = Serialization.serializeToJson(theme);
   });
-  var repl = new Repl(inter, document.body);
-  var motdElement = new SpanElement()..innerHtml = motd;
-  motdElement.querySelector('#github').attributes['href'] =
-      "https://github.com/Cal-CS-61A-Staff/dart_scheme";
-  motdElement.querySelector('#legacy-interpreter').attributes['href'] =
-      "https://scheme-legacy.apps.cs61a.org";
-  motdElement.querySelector('#legacy-editor').attributes['href'] =
-      "https://scheme-legacy.apps.cs61a.org/editor.html";
-  repl.logElement(motdElement);
+  inter.importLibrary(extra);
+  inter.importLibrary(logic);
+  inter.importLibrary(web);
+  new Repl(inter, document.body);
+  var specials = inter.globalEnv.bindings.keys.toSet().difference(normals);
+  inter.importLibrary(new TurtleLibrary(querySelector('canvas'), inter));
+  var turtles = inter.globalEnv.bindings.keys
+      .toSet()
+      .difference(specials)
+      .difference(normals);
+  var demos = new Frame(inter.globalEnv, inter);
+  addDemo(demos, 'try-draw', "(draw '(1 2 3))");
+  addDemo(demos, 'try-chess', "(import 'scm/apps/chess)");
+  addDemo(demos, 'try-ad', "(autodraw)");
+  addDemo(demos, 'try-default', "(theme 'default)");
+  addDemo(demos, 'try-solarized', "(theme 'solarized)");
+  addDemo(demos, 'try-monochrome', "(theme 'monochrome)");
+  addDemo(demos, 'try-monochrome-dark', "(theme 'monochrome-dark)");
+  addDemo(demos, 'try-go-bears', "(theme 'go-bears)");
+  addDemo(demos, 'try-viz', """(define (fact n)
+       (if (= n 0)
+           1
+           (* n (fact (- n 1)))))
+
+     (visualize (fact 5))
+""");
+  context.callMethod('hljsRegister', [
+    new JsObject.jsify({
+      'builtin-normal':
+          normals.union(inter.specialForms.keys.toSet()).join(' '),
+      'builtin-special': specials.join(' '),
+      'builtin-turtle': turtles.join(' ')
+    })
+  ]);
+  inter.logger(new MarkdownElement(motd, env: demos), true);
+}
+
+addDemo(Frame env, String demoName, String code) {
+  addPrimitive(env, new SchemeSymbol.runtime(demoName), (_, __) {
+    var prompt = "<span class='repl-prompt'>scm></span> `$code`";
+    env.interpreter.logger(new MarkdownElement(prompt), true);
+    env.interpreter.run(code);
+    return undefined;
+  }, 0);
 }


### PR DESCRIPTION
MarkdownElements are like TextElements, but with their contents rendered as Markdown. You can create an inline Markdown element with the `formatted` built-in.

Additionally, if you provide a Frame when you create a MarkdownElement, you can add elements like `[Text](:procedure)`, which will create a button that calls `(procedure)` in the provided environment when clicked.

The motd is now logged as a MarkdownElement and now includes highlighted syntax and buttons to launch demos of the various listed features.

This also makes some miscellaneous fixes, mostly to styles and rendering.

New motd:
![Screenshot of new motd](https://user-images.githubusercontent.com/1817677/38538420-9fe89e42-3c48-11e8-87b0-4fa7bb083e20.png)
