### PR TITLE
Auto indent

### DIFF
--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -212,7 +212,10 @@ class Repl {
       runActiveCode();
       await delay(100);
       input.innerHtml = highlight(input.text);
-    } else {
+    } else if ((missingParens ?? 0) > 0 && event.keyCode == KeyCode.ENTER) {
+      event.preventDefault();
+      input.text = input.text + "\n" + " " * spaceCount(input.text);
+    }else {
       await delay(5);
       highlightSaveCursor(input);
     }
@@ -306,5 +309,21 @@ class Repl {
 
   Future delay(int milliseconds) {
     return new Future.delayed(new Duration(milliseconds: milliseconds));
+  }
+
+  int spaceCount(String inputText) {
+    List<String> splitLines = inputText.split("\n");
+    //this is assuming the outermost parens is missing its match
+    String findStartParen(Iterable lines) {
+      int skipParens = '('.allMatches(inputText).length - countParens(inputText);
+      for (String line in lines) {
+        int numParens = '('.allMatches(line).length;
+        if (numParens > skipParens) return line;
+        skipParens -= numParens;
+      }
+    }
+    //TODO: So far, assumes that ( is at the beginning of the line
+    String refLine = findStartParen(splitLines.reversed);
+    return refLine.length - refLine.trimLeft().length;
   }
 }

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -327,8 +327,11 @@ class Repl {
     while (strIndex < refLine.length) {
       int nextClose = refLine.indexOf(")", strIndex + 1);
       int nextOpen = refLine.indexOf("(", strIndex + 1);
-      if (nextOpen == -1 || nextClose == -1 || (nextOpen < nextClose)) break;
-      if (totalMissingCount > 1) totalMissingCount -= 1;
+      if (totalMissingCount > 1) {
+        totalMissingCount -= 1;
+      } else if (nextOpen == -1 || nextClose == -1 || (nextOpen < nextClose)) {
+        break;
+      }
       strIndex = nextOpen;
     }
     return strIndex;

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -353,16 +353,13 @@ class Repl {
       }
     }
     int strIndex = refLine.indexOf("(");
-    while (strIndex < refLine.length) {
+    while (strIndex < (refLine.length - 1)) {
       int nextClose = refLine.indexOf(")", strIndex + 1);
       int nextOpen = refLine.indexOf("(", strIndex + 1);
       if (totalMissingCount > 1) {
         totalMissingCount -= 1;
       } else if (nextOpen == -1 || nextOpen < nextClose) {
         Iterable<Expression> tokens = tokenizeLine(refLine.substring(strIndex));
-        if (tokens.length == 1) {
-          return strIndex + 1;
-        }
         Expression symbol = tokens.elementAt(1);
         if (noIndent.contains(symbol)) {
           return strIndex + 1;
@@ -376,6 +373,7 @@ class Repl {
       }
       strIndex = nextOpen;
     }
+    return strIndex += 1;
   }
 
   bool endOfLine() {

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -216,8 +216,16 @@ class Repl {
       await delay(100);
       input.innerHtml = highlight(input.text);
     } else if ((missingParens ?? 0) > 0 && event.keyCode == KeyCode.ENTER) {
+      //TODO: Add check to see if at the end of the line
+      //TODO: Replace highlightAtEnd 
+      //TODO: Maybe add a primitive to turn autoindent off?
       event.preventDefault();
-      input.text = input.text + "\n" + " " * (spaceCount(input.text) + 1);
+      String newInput = input.text;
+      if (newInput.lastIndexOf("\n") == newInput.length - 1) {
+        newInput = newInput.substring(0, newInput.length - 1);
+      }
+      input.text = newInput + "\n" + " " * (spaceCount(newInput) + 1);
+      //unnecessary to highlight but useful to move the cursor in the correct place
       highlightAtEnd(input, input.text);
     } else {
       await delay(5);

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -216,9 +216,8 @@ class Repl {
       await delay(100);
       input.innerHtml = highlight(input.text);
     } else if ((missingParens ?? 0) > 0 &&
-        event.keyCode == KeyCode.ENTER &&
+        KeyCode.ENTER == event.keyCode &&
         endOfLine()) {
-      //TODO: Replace highlightAtEnd
       //TODO: Maybe add a primitive to turn autoindent off?
       event.preventDefault();
       String newInput = input.text;
@@ -350,9 +349,17 @@ class Repl {
 
   bool endOfLine() {
     Range curr = window.getSelection().getRangeAt(0);
-    Node lastNode = activeInput.childNodes.last;
-    while (lastNode.nodeType != 3) lastNode = lastNode.firstChild;
+    Node lastNode;
+    for (lastNode in activeInput.childNodes.reversed) {
+      if (!lastNode.text.contains(new RegExp(r"^[\n]+$"))) {
+        break;
+      }
+    }
+    while (lastNode.nodeType != Node.TEXT_NODE) lastNode = lastNode.lastChild;
     Range range = new Range()..selectNodeContents(lastNode);
-    return (curr.compareBoundaryPoints(Range.END_TO_END, range) == 0);
+    int index = lastNode.text.length - 1;
+    while (index >= 0 && lastNode.text[index] == "\n") index -= 1;
+    return curr.endContainer == range.endContainer &&
+        curr.endOffset == (index + 1);
   }
 }

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -215,17 +215,17 @@ class Repl {
       runActiveCode();
       await delay(100);
       input.innerHtml = highlight(input.text);
-    } else if ((missingParens ?? 0) > 0 && event.keyCode == KeyCode.ENTER) {
-      //TODO: Add check to see if at the end of the line
-      //TODO: Replace highlightAtEnd 
+    } else if ((missingParens ?? 0) > 0 &&
+        event.keyCode == KeyCode.ENTER &&
+        endOfLine()) {
+      //TODO: Replace highlightAtEnd
       //TODO: Maybe add a primitive to turn autoindent off?
       event.preventDefault();
       String newInput = input.text;
-      if (newInput.lastIndexOf("\n") == newInput.length - 1) {
+      if (newInput[newInput.length - 1] == "\n") {
         newInput = newInput.substring(0, newInput.length - 1);
       }
       input.text = newInput + "\n" + " " * (spaceCount(newInput) + 1);
-      //unnecessary to highlight but useful to move the cursor in the correct place
       highlightAtEnd(input, input.text);
     } else {
       await delay(5);
@@ -346,5 +346,13 @@ class Repl {
       strIndex = nextOpen;
     }
     return strIndex;
+  }
+
+  bool endOfLine() {
+    Range curr = window.getSelection().getRangeAt(0);
+    Node lastNode = activeInput.childNodes.last;
+    while (lastNode.nodeType != 3) lastNode = lastNode.firstChild;
+    Range range = new Range()..selectNodeContents(lastNode);
+    return (curr.compareBoundaryPoints(Range.END_TO_END, range) == 0);
   }
 }

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -23,7 +23,8 @@ class Repl {
   List<SchemeSymbol> noIndent = [
     new SchemeSymbol("let"),
     new SchemeSymbol("("),
-    new SchemeSymbol("define")
+    new SchemeSymbol("define"),
+    new SchemeSymbol("lambda")
   ];
 
   Repl(this.interpreter, Element parent) {
@@ -70,7 +71,7 @@ class Repl {
   }
 
   bool autodraw = false;
-  bool autoindent = true;
+  bool autoindent = false;
 
   addPrimitives() {
     var env = interpreter.globalEnv;
@@ -89,7 +90,7 @@ class Repl {
       return undefined;
     }, 0);
     addPrimitive(env, const SchemeSymbol('disable-autodraw'), (_a, _b) {
-      logText('Autodraw disabled');
+      logText('Autodraw disabled\n');
       autodraw = false;
       return undefined;
     }, 0);
@@ -101,7 +102,7 @@ class Repl {
       return undefined;
     }, 0);
     addPrimitive(env, const SchemeSymbol('disable-autoindent'), (_a, _b) {
-      logText('Autoindent disabled');
+      logText('Autoindent disabled\n');
       autoindent = false;
       return undefined;
     }, 0);
@@ -359,15 +360,16 @@ class Repl {
         totalMissingCount -= 1;
       } else if (nextOpen == -1 || nextOpen < nextClose) {
         Iterable<Expression> tokens = tokenizeLine(refLine.substring(strIndex));
+        if (tokens.length == 1) {
+          return strIndex + 1;
+        }
         Expression symbol = tokens.elementAt(1);
         if (noIndent.contains(symbol)) {
           return strIndex + 1;
-        } else if (nextOpen == -1 && tokens.length > 2) {
-          return refLine.indexOf(tokens.elementAt(2).toString(), strIndex);
+        } else if (tokens.length > 2) {
+          return refLine.indexOf(tokens.elementAt(2).toString(), strIndex + 1);
         } else if (nextOpen == -1) {
           return strIndex + 1;
-        } else {
-          return nextOpen;
         }
       } else if (nextClose == -1) {
         return strIndex + 1;

--- a/web/scm/apps/drawing.scm
+++ b/web/scm/apps/drawing.scm
@@ -1,0 +1,21 @@
+(define (hax-mod d k lst)
+    (color (car lst))
+    (begin_fill)
+    (repeat leg 6)
+    (end_fill)
+    (if (= k 0) nil (repeat subhax 3)))
+
+(define repeat (mu (f n) (f) (if (> n 1) (repeat f (- n 1)))))
+
+(define subhax (mu () (hax-mod (/ d 2) (- k 1) (cdr lst)) (repeat leg 2)))
+
+(define leg (mu () (forward d) (left 60)))
+
+(define (draw) (turtle-grid 800 800) (turtle-canvas 800 800)
+    (goto 384 0)
+    (color "#181818")
+    (begin_fill) (circle 384) (end_fill)
+    (circle 384 -30)
+    (seth 0)
+    (hax-mod 384 5 (list "#181818" "#041e42" "#ffc72c" "#041e42" "#ffc72c" "#041e42")))
+(draw)

--- a/web/scm/apps/drawing.scm
+++ b/web/scm/apps/drawing.scm
@@ -1,3 +1,6 @@
+; CalDay 2018 Demo
+; Go to scheme.cs61a.org to run this code on your own computer
+
 (define (hax-mod d k lst)
     (color (car lst))
     (begin_fill)


### PR DESCRIPTION
Closes #16 

There's one bug that I found that I couldn't figure out how to fix where if someone presses enter twice without writing anything, the autoindent will no longer work for the next line. I think this is actually a similar problem to what goes on in highlightSaveCursor. From what I was able to gather, when a new line is created, some funky things happen with the HTML that seemed kind of difficult to get around. I think that the start and end offset no longer refer to the offset from the beginning of the text itself. 

Other than that, autoindent currently only works after you call the procedure (autoindent).

The way that I intended for this to work was for something like if statements and most other functions and procedures to look like the following with all the subexpressions having the same indent:

```
(if predicate
    consequent
    alternative)
```

I modified some things, like let statements for example to work like this where the body is not lined up with the other subexpressions:
```
(let ( (symbol expr)
       (symbol expr) )
  body)
```