### PR TITLE
Adds a standalone Logic interpreter.

### DIFF
--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -7,6 +7,7 @@ import 'package:cs61a_scheme/cs61a_scheme.dart';
 import 'async.dart';
 import 'diagramming.dart';
 import 'flag_trace.dart';
+import 'logic_library.dart';
 import 'operand_procedures.dart';
 import 'visualization.dart';
 
@@ -145,5 +146,10 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   MarkdownElement formatted(List<Expression> expressions, Frame env) {
     String text = expressions.map((expr) => expr.display).join('');
     return new MarkdownElement(text, inline: true, env: env);
+  }
+
+  @SchemeSymbol('logic')
+  void logicStart(Frame env) {
+    env.interpreter.importLibrary(new LogicLibrary());
   }
 }

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -19,6 +19,7 @@ abstract class _$ExtraLibraryMixin {
   String serialize(Serializable expr);
   Expression deserialize(String json);
   MarkdownElement formatted(List<Expression> expressions, Frame env);
+  void logicStart(Frame env);
   void importAll(Frame __env) {
     addPrimitive(__env, const SchemeSymbol("run-async"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)
@@ -117,5 +118,10 @@ abstract class _$ExtraLibraryMixin {
         (__exprs, __env) {
       return this.formatted(__exprs, __env);
     }, 0, -1);
+    addPrimitive(__env, const SchemeSymbol('logic'), (__exprs, __env) {
+      var __value = undefined;
+      this.logicStart(__env);
+      return __value;
+    }, 0);
   }
 }

--- a/lib/src/extra/logic_library.dart
+++ b/lib/src/extra/logic_library.dart
@@ -18,7 +18,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
   @SchemeSymbol('fact')
   @SchemeSymbol('!')
   @noeval
-  void fact(List<Expression> exprs, Frame env) {
+  void fact(List<Expression> exprs) {
     facts.add(new logic.Fact(exprs.first, exprs.skip(1)));
   }
 
@@ -50,7 +50,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
   }
 
   @SchemeSymbol('prolog')
-  String prolog(Frame env) {
-    return facts[env].map((f) => f.toProlog()).join('\n') + '\n';
+  String prolog() {
+    return facts.map((f) => f.toProlog()).join('\n') + '\n';
   }
 }

--- a/lib/src/extra/logic_library.dart
+++ b/lib/src/extra/logic_library.dart
@@ -13,30 +13,13 @@ part 'logic_library.g.dart';
 /// the primitives and performs type checking on arguments).
 @schemelib
 class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
-  Map<Frame, List<logic.Fact>> facts = new Map.identity();
-
-  @override
-  void importAll(Frame env) {
-    Frame child = new Frame(env, env.interpreter);
-    super.importAll(child);
-    var sym = const SchemeSymbol('logic');
-
-    // Only import the loader to start. Calling logic imports the rest.
-    env.define(sym, child.bindings[sym]);
-    env.hidden[sym] = true;
-  }
-
-  @SchemeSymbol('logic')
-  void logicStart(Frame env) {
-    super.importAll(env);
-  }
+  List<logic.Fact> facts = [];
 
   @SchemeSymbol('fact')
   @SchemeSymbol('!')
   @noeval
   void fact(List<Expression> exprs, Frame env) {
-    if (!facts.containsKey(env)) facts[env] = [];
-    facts[env].add(new logic.Fact(exprs.first, exprs.skip(1)));
+    facts.add(new logic.Fact(exprs.first, exprs.skip(1)));
   }
 
   @SchemeSymbol('query')
@@ -44,7 +27,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
   @noeval
   void query(List<Expression> exprs, Frame env) {
     bool success = false;
-    for (var sol in logic.evaluate(new logic.Query(exprs), facts[env] ?? [])) {
+    for (var sol in logic.evaluate(new logic.Query(exprs), facts)) {
       if (!success) env.interpreter.logText('Success!');
       success = true;
       env.interpreter.logger(sol, true);
@@ -56,7 +39,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
   @SchemeSymbol('query-one')
   @noeval
   void queryOne(List<Expression> exprs, Frame env) {
-    var sols = logic.evaluate(new logic.Query(exprs), facts[env] ?? []);
+    var sols = logic.evaluate(new logic.Query(exprs), facts);
     if (sols.isNotEmpty) {
       env.interpreter.logText('Success!');
       env.interpreter.logger(sols.first, true);

--- a/lib/src/extra/logic_library.g.dart
+++ b/lib/src/extra/logic_library.g.dart
@@ -1,16 +1,10 @@
 part of cs61a_scheme.extra.logic_library;
 
 abstract class _$LogicLibraryMixin {
-  void logicStart(Frame env);
   void fact(List<Expression> exprs, Frame env);
   void query(List<Expression> exprs, Frame env);
   void queryOne(List<Expression> exprs, Frame env);
   void importAll(Frame __env) {
-    addPrimitive(__env, const SchemeSymbol('logic'), (__exprs, __env) {
-      var __value = undefined;
-      this.logicStart(__env);
-      return __value;
-    }, 0);
     addVariableOperandPrimitive(__env, const SchemeSymbol('fact'),
         (__exprs, __env) {
       var __value = undefined;

--- a/lib/src/extra/logic_library.g.dart
+++ b/lib/src/extra/logic_library.g.dart
@@ -1,15 +1,15 @@
 part of cs61a_scheme.extra.logic_library;
 
 abstract class _$LogicLibraryMixin {
-  void fact(List<Expression> exprs, Frame env);
+  void fact(List<Expression> exprs);
   void query(List<Expression> exprs, Frame env);
   void queryOne(List<Expression> exprs, Frame env);
-  String prolog(Frame env);
+  String prolog();
   void importAll(Frame __env) {
     addVariableOperandPrimitive(__env, const SchemeSymbol('fact'),
         (__exprs, __env) {
       var __value = undefined;
-      this.fact(__exprs, __env);
+      this.fact(__exprs);
       return __value;
     }, 0, -1);
     __env.bindings[const SchemeSymbol('!')] =
@@ -31,7 +31,7 @@ abstract class _$LogicLibraryMixin {
       return __value;
     }, 0, -1);
     addPrimitive(__env, const SchemeSymbol('prolog'), (__exprs, __env) {
-      return new SchemeString(this.prolog(__env));
+      return new SchemeString(this.prolog());
     }, 0);
   }
 }

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -20,13 +20,15 @@ class Repl {
   List<String> history = [];
   int historyIndex = -1;
 
+  final String prompt;
+
   List<SchemeSymbol> noIndent = [
     const SchemeSymbol("let"),
     const SchemeSymbol("define"),
     const SchemeSymbol("lambda")
   ];
 
-  Repl(this.interpreter, Element parent) {
+  Repl(this.interpreter, Element parent, {this.prompt}) {
     if (window.localStorage.containsKey('#repl-history')) {
       var decoded = json.decode(window.localStorage['#repl-history']);
       if (decoded is List) history = decoded.map((item) => '$item').toList();
@@ -102,7 +104,7 @@ class Repl {
     }
     container.append(activeLoggingArea);
     activePrompt = new SpanElement()
-      ..text = 'scm> '
+      ..text = prompt
       ..classes = ['repl-prompt'];
     container.append(activePrompt);
     activeInput = new SpanElement()

--- a/web/main.dart
+++ b/web/main.dart
@@ -37,14 +37,8 @@ Shift+Enter to add missing parens and run the current input
 """;
 
 main() async {
-  var inter = new Interpreter(new StaffProjectImplementation());
-  var normals = inter.globalEnv.bindings.keys.toSet();
-  var extra = new ExtraLibrary();
-  var logic = new LogicLibrary();
-  var diagramBox = querySelector('#diagram');
   String css = await HttpRequest.getString('assets/style.css');
   var style = querySelector('#theme');
-  var web = new WebLibrary(diagramBox, context['jsPlumb'], css, style);
   if (window.localStorage.containsKey('#scheme-theme')) {
     try {
       var expr = Serialization
@@ -60,9 +54,21 @@ main() async {
   onThemeChange.listen((Theme theme) {
     window.localStorage['#scheme-theme'] = Serialization.serializeToJson(theme);
   });
+  var diagramBox = querySelector('#diagram');
+  var webLibrary = new WebLibrary(diagramBox, context['jsPlumb'], css, style);
+  if (window.location.href.contains('logic')) {
+    await startLogic(webLibrary);
+  } else {
+    await startScheme(webLibrary);
+  }
+}
+
+startScheme(WebLibrary webLibrary) async {
+  var inter = new Interpreter(new StaffProjectImplementation());
+  var normals = inter.globalEnv.bindings.keys.toSet();
+  var extra = new ExtraLibrary();
   inter.importLibrary(extra);
-  inter.importLibrary(logic);
-  inter.importLibrary(web);
+  inter.importLibrary(webLibrary);
   new Repl(inter, document.body);
   var specials = inter.globalEnv.bindings.keys.toSet().difference(normals);
   inter.importLibrary(new TurtleLibrary(querySelector('canvas'), inter));
@@ -105,6 +111,54 @@ addDemo(Frame env, String demoName, String code) {
     var prompt = "<span class='repl-prompt'>scm></span> `$code`";
     env.interpreter.logger(new MarkdownElement(prompt), true);
     env.interpreter.run(code);
+    return undefined;
+  }, 0);
+}
+
+const String logicMotd = "**61A Logic Web Interpreter**"
+    "                                     <small>"
+    "[View Source on GitHub](https://github.com/Cal-CS-61A-Staff/dart_scheme)"
+    """</small>
+--------------------------------------------------------------------------------
+**Themes**
+[default](:default) [solarized](:solarized) [monochrome](:monochrome) """
+    """[monochrome-dark](:monochrome-dark) [go-bears](:go-bears)
+
+**Usage**
+`(fact consequent hypothesis1 ...)` or `(! consequent hypothesis1 ...)`:
+  Assert a consequent, followed by zero or more hypotheses.
+`(query clause1 clause2 ...)` or `(? clause1 clause2 ...)`
+  Query zero or more relations simultaneously.
+`(query-one clause1 clause2 ...)`
+  Like query, but finds at most one solution.
+
+""";
+
+startLogic(WebLibrary webLibrary) {
+  document.title = 'Logic Interpreter';
+  var inter = new Interpreter(new StaffProjectImplementation());
+  new Repl(inter, document.body, prompt: 'logic> ');
+  inter.globalEnv.bindings.clear();
+  inter.specialForms.clear();
+  inter.importLibrary(new LogicLibrary());
+  var keywords = inter.globalEnv.bindings.keys.toSet();
+  context.callMethod('hljsRegister', [
+    new JsObject.jsify({'builtin-special': keywords.join(' ')})
+  ]);
+  var themeInter = new Interpreter(new StaffProjectImplementation());
+  themeInter.importLibrary(new ExtraLibrary());
+  themeInter.importLibrary(webLibrary);
+  addTheme(themeInter, webLibrary, const SchemeSymbol('default'));
+  addTheme(themeInter, webLibrary, const SchemeSymbol('solarized'));
+  addTheme(themeInter, webLibrary, const SchemeSymbol('monochrome'));
+  addTheme(themeInter, webLibrary, const SchemeSymbol('monochrome-dark'));
+  addTheme(themeInter, webLibrary, const SchemeSymbol('go-bears'));
+  inter.logger(new MarkdownElement(logicMotd, env: themeInter.globalEnv), true);
+}
+
+addTheme(Interpreter inter, WebLibrary web, SchemeSymbol themeName) {
+  addPrimitive(inter.globalEnv, themeName, (_, __) {
+    web.theme(themeName, inter.globalEnv);
     return undefined;
   }, 0);
 }


### PR DESCRIPTION
Closes #58 and #60.

When the window's location includes "logic" somewhere in it, a standalone Logic interpreter is started instead of the normal Scheme interpreter.

To accomplish this, the global env and special forms of the Interpreter are cleared prior to loading the LogicLibrary.

A separate Intepreter instance is linked to buttons that can change the theme (this cannot be done through code from the standalone Logic interpreter.

As part of these changes, the `(logic)` built-in has been moved to the ExtraLibrary, and it now load the entire LogicLibrary when called within a normal Scheme interpreter. Since a new LogicLibrary is imported each time, it creates a new Logic environment for each call.