### PR TITLE
Refactor diagram/rendering code

### DIFF
--- a/lib/cs61a_scheme.dart
+++ b/lib/cs61a_scheme.dart
@@ -16,5 +16,5 @@ export 'src/core/reader.dart';
 export 'src/core/scheme_library.dart';
 export 'src/core/serialization.dart';
 export 'src/core/standard_library.dart';
-export 'src/core/ui.dart';
 export 'src/core/utils.dart';
+export 'src/core/widgets.dart';

--- a/lib/cs61a_scheme_web.dart
+++ b/lib/cs61a_scheme_web.dart
@@ -2,9 +2,9 @@ library cs61a_scheme.web;
 
 export 'package:cs61a_scheme/cs61a_scheme_extra.dart';
 
-export 'src/web/html_ui.dart';
 export 'src/web/imports.dart';
 export 'src/web/js_interop.dart';
+export 'src/web/renderer.dart';
 export 'src/web/theming.dart';
 export 'src/web/turtle.dart';
 export 'src/web/turtle_library.dart';

--- a/lib/src/core/expressions.dart
+++ b/lib/src/core/expressions.dart
@@ -9,8 +9,8 @@ import 'package:quiver_hashcode/hashcode.dart';
 import 'interpreter.dart';
 import 'logging.dart';
 import 'serialization.dart';
-import 'ui.dart';
 import 'utils.dart';
+import 'widgets.dart';
 
 /// Base class for all Scheme data types.
 ///
@@ -28,14 +28,14 @@ abstract class Expression {
   ///
   /// If true, this expression should be inlined in diagrams.
   /// If false, it should be added to the objects with an arrow to it.
-  bool get inlineUI => false;
+  bool get inlineInDiagram => false;
 
-  /// Constructs a [UIElement] for this expression.
+  /// Constructs a [Widget] for this expression.
   ///
   /// The default implementation returns the string representation of this
-  /// expression as a [TextElement]. Some expressions may need to add
+  /// expression as a [TextWidget]. Some expressions may need to add
   /// additional objects to [diagram].
-  UIElement draw(DiagramInterface diagram) => new TextElement(toString());
+  Widget draw(DiagramInterface diagram) => new TextWidget(toString());
 
   /// Shorthand for `expr is EmptyList`.
   bool get isNil => false;
@@ -65,7 +65,7 @@ abstract class SelfEvaluating extends Expression {
 
 /// A Scheme boolean. There are only two: [schemeTrue] and [schemeFalse].
 class Boolean extends SelfEvaluating implements Serializable<Boolean> {
-  final inlineUI = true;
+  final inlineInDiagram = true;
   final bool value;
   const Boolean._internal(this.value);
   bool get isTruthy => value;
@@ -95,7 +95,7 @@ const schemeFalse = const Boolean._internal(false);
 /// create a constant instance, a lowercase string should be passed to maintain
 /// this. Use the [runtime] constructor when passing in non-constant strings.
 class SchemeSymbol extends Expression implements Serializable<SchemeSymbol> {
-  final inlineUI = true;
+  final inlineInDiagram = true;
   final String value;
 
   const SchemeSymbol(this.value);
@@ -113,7 +113,7 @@ class SchemeSymbol extends Expression implements Serializable<SchemeSymbol> {
 /// A Scheme string.
 class SchemeString extends SelfEvaluating
     implements Serializable<SchemeString> {
-  final inlineUI = true;
+  final inlineInDiagram = true;
   final String value;
   const SchemeString(this.value);
   toString() => json.encode(value);
@@ -182,7 +182,7 @@ abstract class PairOrEmpty extends Expression implements Iterable<Expression> {
 /// constructor, so we have to implement all the [Iterable] methods ourselves.
 class _EmptyList extends IterableBase<Expression>
     implements SelfEvaluating, PairOrEmpty {
-  final inlineUI = true;
+  final inlineInDiagram = true;
   const _EmptyList();
   bool get wellFormed => true;
   @deprecated
@@ -194,7 +194,7 @@ class _EmptyList extends IterableBase<Expression>
   num get lengthOrCycle => 0;
 
   get display => toString();
-  draw(DiagramInterface diagram) => new TextElement('()');
+  draw(DiagramInterface diagram) => new TextWidget('()');
   evaluate(Frame env) => this;
   get isTruthy => true;
   get pair => this as Pair;
@@ -247,10 +247,10 @@ class Pair<A extends Expression, B extends Expression> extends Expression
   Expression evaluate(Frame env) => evalCallExpression(this, env);
 
   @override
-  UIElement draw(DiagramInterface diagram) {
+  Widget draw(DiagramInterface diagram) {
     int parentRow = diagram.currentRow;
-    UIElement right = diagram.pointTo(second);
-    UIElement left = diagram.pointTo(first, parentRow);
+    Widget right = diagram.pointTo(second);
+    Widget left = diagram.pointTo(first, parentRow);
     return new BlockGrid.pair(new Block.pair(left), new Block.pair(right));
   }
 
@@ -386,8 +386,8 @@ class Promise extends SelfEvaluating {
 
   /// Promises are represented in diagrams as a circle with ⋯ inside prior to
   /// forcing, and the evaluated result afterwards.
-  UIElement draw(DiagramInterface diagram) {
-    var inside = _evaluated ? diagram.pointTo(expr) : new TextElement("⋯");
+  Widget draw(DiagramInterface diagram) {
+    var inside = _evaluated ? diagram.pointTo(expr) : new TextWidget("⋯");
     return new Block.promise(inside);
   }
 }

--- a/lib/src/core/interpreter.dart
+++ b/lib/src/core/interpreter.dart
@@ -8,7 +8,6 @@ import 'project_interface.dart';
 import 'scheme_library.dart';
 import 'special_forms.dart';
 import 'standard_library.dart';
-import 'ui.dart';
 import 'utils.dart' show schemeEval;
 
 class Interpreter {
@@ -17,7 +16,6 @@ class Interpreter {
   ProjectInterface get implementation => impl;
   Frame globalEnv;
   bool tailCallOptimized = true;
-  Renderer renderer = (UIElement) => null;
   Logger _logger = (Expression e, bool newline) => null;
   Logger get logger => _logger;
   void set logger(Logger logger) => _logger = logger;

--- a/lib/src/core/numbers.dart
+++ b/lib/src/core/numbers.dart
@@ -16,7 +16,7 @@ import 'serialization.dart';
 /// With the exception of true division, all arithmetic operations between two
 /// [Integer] expressions should return another [Integer].
 abstract class Number extends SelfEvaluating {
-  final inlineUI = true;
+  final inlineInDiagram = true;
   dynamic get value;
 
   Number();

--- a/lib/src/core/procedures.dart
+++ b/lib/src/core/procedures.dart
@@ -2,7 +2,7 @@ library cs61a_scheme.core.procedures;
 
 import 'expressions.dart';
 import 'logging.dart';
-import 'ui.dart';
+import 'widgets.dart';
 
 /// Base class for all Scheme procedures.
 ///
@@ -115,7 +115,7 @@ abstract class UserDefinedProcedure extends Procedure {
   }
 
   @override
-  UIElement draw(diag) => new TextElement(new Pair(name, formals).toString());
+  Widget draw(diag) => new TextWidget(new Pair(name, formals).toString());
 }
 
 /// A [UserDefinedProcedure] with lexical scope and normal operand evaluation.
@@ -148,10 +148,10 @@ class LambdaProcedure extends UserDefinedProcedure {
       new Pair(new SchemeSymbol('lambda'), new Pair(formals, body)).toString();
 
   @override
-  UIElement draw(diag) {
+  Widget draw(diag) {
     var parent = env.id == 0 ? '' : ' [parent=f${env.id}]';
     var msg = "${new Pair(name, formals)}$parent";
-    return new TextElement(msg);
+    return new TextWidget(msg);
   }
 }
 

--- a/lib/src/core/serialization.dart
+++ b/lib/src/core/serialization.dart
@@ -5,7 +5,7 @@ import 'package:dart2_constant/convert.dart' show json;
 import 'expressions.dart';
 import 'numbers.dart';
 import 'logging.dart';
-import 'ui.dart';
+import 'widgets.dart';
 
 final Map<String, Serializable> deserializers = {
   'Integer': Number.zero,
@@ -14,8 +14,8 @@ final Map<String, Serializable> deserializers = {
   'SchemeSymbol': const SchemeSymbol('x'),
   'SchemeString': const SchemeString('x'),
   'Anchor': new Anchor.withId(-1),
-  'TextElement': new TextElement(""),
-  'MarkdownElement': new MarkdownElement(null),
+  'TextWidget': new TextWidget(""),
+  'MarkdownWidget': new MarkdownWidget(null),
   'Strike': new Strike(),
   'Block': new Block.pair(null),
   'BlockGrid': new BlockGrid([[]])

--- a/lib/src/extra/async.dart
+++ b/lib/src/extra/async.dart
@@ -41,9 +41,9 @@ class AsyncExpression<T extends Expression> extends Expression {
   };
 
   @override
-  UIElement draw(DiagramInterface diagram) {
-    UIElement inside =
-        complete ? diagram.pointTo(result) : new TextElement("async");
+  Widget draw(DiagramInterface diagram) {
+    Widget inside =
+        complete ? diagram.pointTo(result) : new TextWidget("async");
     return new Block.async(inside);
   }
 }

--- a/lib/src/extra/diagramming.dart
+++ b/lib/src/extra/diagramming.dart
@@ -14,9 +14,9 @@ class Arrow extends SelfEvaluating implements Serializable<Arrow> {
   }
 }
 
-class Binding extends UIElement {
+class Binding extends Widget {
   final SchemeSymbol symbol;
-  final UIElement value;
+  final Widget value;
   final bool isReturn;
   Binding(this.symbol, this.value, [this.isReturn = false]);
   Map serialize() => finishSerialize({
@@ -32,8 +32,8 @@ class Binding extends UIElement {
   }
 }
 
-class Row extends UIElement {
-  final List<UIElement> elements;
+class Row extends Widget {
+  final List<Widget> elements;
   Row(this.elements);
   toString() => elements.toString();
   Map serialize() => finishSerialize({
@@ -45,7 +45,7 @@ class Row extends UIElement {
         ..finishDeserialize(data);
 }
 
-class FrameElement extends UIElement {
+class FrameElement extends Widget {
   int id;
   String tag;
   int parentId;
@@ -157,12 +157,12 @@ class Diagram extends DiagramInterface {
     _incompleteArrows.clear();
   }
 
-  Map<Expression, UIElement> _known = new Map.identity();
+  Map<Expression, Widget> _known = new Map.identity();
   List<Pair<Anchor, Expression>> _incompleteArrows = [];
 
   Anchor _handleExisting(Expression expression) {
     Anchor anchor = new Anchor();
-    UIElement element = _known[expression];
+    Widget element = _known[expression];
     if (element == null) {
       _incompleteArrows.add(new Pair(anchor, expression));
     } else {
@@ -171,32 +171,32 @@ class Diagram extends DiagramInterface {
     return anchor;
   }
 
-  UIElement _build(Expression expression) {
+  Widget _build(Expression expression) {
     _known[expression] = null;
-    UIElement element = expression.draw(this);
+    Widget element = expression.draw(this);
     _known[expression] = element;
     return element;
   }
 
-  UIElement bindingTo(Expression expression) {
-    if (expression.inlineUI) return expression.draw(this);
+  Widget bindingTo(Expression expression) {
+    if (expression.inlineInDiagram) return expression.draw(this);
     if (_known.containsKey(expression)) return _handleExisting(expression);
     if (rows.last.elements.isNotEmpty) rows.add(new Row([]));
     int myRow = rows.length - 1;
-    UIElement element = _build(expression);
+    Widget element = _build(expression);
     rows[myRow].elements.insert(0, element);
     Anchor anchor = new Anchor();
     arrows.add(new Arrow(anchor, element.anchor(Direction.left)));
     return anchor;
   }
 
-  UIElement pointTo(Expression expression, [int parentRow = null]) {
+  Widget pointTo(Expression expression, [int parentRow = null]) {
     if (expression == nil) return new Strike();
-    if (expression.inlineUI) return expression.draw(this);
+    if (expression.inlineInDiagram) return expression.draw(this);
     if (_known.containsKey(expression)) return _handleExisting(expression);
     if (parentRow != null) rows.add(new Row([]));
     int myRow = rows.length - 1;
-    UIElement element = _build(expression);
+    Widget element = _build(expression);
     rows[myRow].elements.insert(0, element);
     if (parentRow != null) {
       _rowParent[myRow] = parentRow;
@@ -204,7 +204,7 @@ class Diagram extends DiagramInterface {
     }
     Anchor anchor = new Anchor();
     Direction dir = parentRow != null ? Direction.top : Direction.left;
-    UIElement anchoring = element;
+    Widget anchoring = element;
     if (element is BlockGrid) anchoring = element.rowAt(0).first;
     arrows.add(new Arrow(anchor, anchoring.anchor(dir)));
     return anchor;

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -62,10 +62,6 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   Boolean isCompleted(AsyncExpression expr) =>
       expr.complete ? schemeTrue : schemeFalse;
 
-  void render(UIElement ui, Frame env) {
-    env.interpreter.renderer(ui);
-  }
-
   Diagram draw(Expression expression) {
     return new Diagram(expression);
   }
@@ -143,9 +139,9 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
     return Serialization.deserializeFromJson(json);
   }
 
-  MarkdownElement formatted(List<Expression> expressions, Frame env) {
+  MarkdownWidget formatted(List<Expression> expressions, Frame env) {
     String text = expressions.map((expr) => expr.display).join('');
-    return new MarkdownElement(text, inline: true, env: env);
+    return new MarkdownWidget(text, inline: true, env: env);
   }
 
   @SchemeSymbol('logic')

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -4,7 +4,6 @@ abstract class _$ExtraLibraryMixin {
   Future<Expression> runAsync(Procedure proc, Frame env);
   Future<Expression> runAfter(Number millis, Procedure proc, Frame env);
   Boolean isCompleted(AsyncExpression expr);
-  void render(UIElement ui, Frame env);
   Diagram draw(Expression expression);
   Diagram diagram(Frame env);
   Visualization visualize(Expression code, Frame env);
@@ -18,7 +17,7 @@ abstract class _$ExtraLibraryMixin {
   Visualization traceToVisualization(FlagTrace trace);
   String serialize(Serializable expr);
   Expression deserialize(String json);
-  MarkdownElement formatted(List<Expression> expressions, Frame env);
+  MarkdownWidget formatted(List<Expression> expressions, Frame env);
   void logicStart(Frame env);
   void importAll(Frame __env) {
     addPrimitive(__env, const SchemeSymbol("run-async"), (__exprs, __env) {
@@ -38,13 +37,6 @@ abstract class _$ExtraLibraryMixin {
         throw new SchemeException(
             'Argument of invalid type passed to completed?.');
       return this.isCompleted(__exprs[0]);
-    }, 1);
-    addPrimitive(__env, const SchemeSymbol("render"), (__exprs, __env) {
-      if (__exprs[0] is! UIElement)
-        throw new SchemeException('Argument of invalid type passed to render.');
-      var __value = undefined;
-      this.render(__exprs[0], __env);
-      return __value;
     }, 1);
     addPrimitive(__env, const SchemeSymbol("draw"), (__exprs, __env) {
       return this.draw(__exprs[0]);

--- a/lib/src/extra/visualization.dart
+++ b/lib/src/extra/visualization.dart
@@ -7,9 +7,9 @@ import 'package:cs61a_scheme/cs61a_scheme.dart';
 import 'diagramming.dart';
 import 'flag_trace.dart';
 
-class Button extends UIElement {
+class Button extends Widget {
   void Function() click;
-  UIElement inside;
+  Widget inside;
   Button(this.inside, this.click);
   Button.forEvent(
       this.inside, SchemeSymbol id, List<Expression> data, Frame env) {
@@ -21,7 +21,7 @@ class Button extends UIElement {
   deserialize(data) => null;
 }
 
-class Visualization extends UIElement {
+class Visualization extends Widget {
   Frame env;
   Expression code;
   List<Diagram> diagrams = [];
@@ -29,7 +29,7 @@ class Visualization extends UIElement {
   int current = 0;
 
   Diagram get currentDiagram => diagrams[current];
-  List<UIElement> buttonRow;
+  List<Widget> buttonRow;
   Expression result;
 
   Visualization(this.code, this.env) {
@@ -73,16 +73,16 @@ class Visualization extends UIElement {
         animating = false;
       }
       current = index;
-      buttonRow[2] = new TextElement("${current+1}/${diagrams.length}");
+      buttonRow[2] = new TextWidget("${current+1}/${diagrams.length}");
       update();
     }
 
-    Button first = new Button(new TextElement("<<"), () => goto(0));
-    Button prev = new Button(new TextElement("<"), () => goto(current - 1));
-    TextElement status = new TextElement("${current+1}/${diagrams.length}");
-    Button next = new Button(new TextElement(">"), () => goto(current + 1));
-    Button last = new Button(new TextElement(">>"), () => goto(-1));
-    Button animate = new Button(new TextElement("Animate"), () async {
+    Button first = new Button(new TextWidget("<<"), () => goto(0));
+    Button prev = new Button(new TextWidget("<"), () => goto(current - 1));
+    TextWidget status = new TextWidget("${current+1}/${diagrams.length}");
+    Button next = new Button(new TextWidget(">"), () => goto(current + 1));
+    Button last = new Button(new TextWidget(">>"), () => goto(-1));
+    Button animate = new Button(new TextWidget("Animate"), () async {
       if (animating) {
         animating = false;
         return;

--- a/lib/src/web/web_library.dart
+++ b/lib/src/web/web_library.dart
@@ -6,7 +6,6 @@ import 'dart:js';
 
 import 'package:cs61a_scheme/cs61a_scheme_extra.dart';
 
-import 'html_ui.dart';
 import 'imports.dart';
 import 'js_interop.dart';
 import 'theming.dart';
@@ -18,12 +17,11 @@ part 'web_library.g.dart';
 /// the primitives and performs type checking on arguments).
 @schemelib
 class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
-  final html.Element renderContainer;
   final JsObject jsPlumb;
   final String css;
   final html.Element styleElement;
 
-  WebLibrary(this.renderContainer, this.jsPlumb, this.css, this.styleElement) {
+  WebLibrary(this.jsPlumb, this.css, this.styleElement) {
     Undefined.jsUndefined = context['undefined'];
     AsyncExpression.makePromise = (expr) {
       return new JsObject(context['Promise'], [
@@ -40,16 +38,9 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
 
   void importAll(Frame env) {
     super.importAll(env);
-    env.interpreter.renderer =
-        new HtmlRenderer(renderContainer, jsPlumb).render;
     Procedure.jsProcedure = (procedure) {
       return new SchemeFunction(procedure, env);
     };
-  }
-
-  @SchemeSymbol("close-diagram")
-  void closeDiagram(Frame env) {
-    env.interpreter.renderer(new TextElement(""));
   }
 
   Expression js(List<Expression> exprs) {

--- a/lib/src/web/web_library.g.dart
+++ b/lib/src/web/web_library.g.dart
@@ -1,7 +1,6 @@
 part of cs61a_scheme.web.web_library;
 
 abstract class _$WebLibraryMixin {
-  void closeDiagram(Frame env);
   Expression js(List<Expression> exprs);
   Expression jsContext();
   Expression jsSet(JsExpression obj, Expression property, Expression value);
@@ -23,11 +22,6 @@ abstract class _$WebLibraryMixin {
   Future<Expression> theme(SchemeSymbol theme, Frame env);
   String colorToCss(Color color);
   void importAll(Frame __env) {
-    addPrimitive(__env, const SchemeSymbol("close-diagram"), (__exprs, __env) {
-      var __value = undefined;
-      this.closeDiagram(__env);
-      return __value;
-    }, 0);
     addVariablePrimitive(__env, const SchemeSymbol("js"), (__exprs, __env) {
       return this.js(__exprs);
     }, 0, -1);

--- a/lib/web_repl.dart
+++ b/lib/web_repl.dart
@@ -3,7 +3,6 @@ library web_repl;
 import 'dart:async';
 import 'package:dart2_constant/convert.dart' show json;
 import 'dart:html';
-import 'dart:js';
 
 import 'package:cs61a_scheme/cs61a_scheme_web.dart';
 import 'package:cs61a_scheme/highlight.dart';
@@ -299,10 +298,9 @@ class Repl {
       });
     } else if (logging == null) {
       element.text = '';
-    } else if (logging is UIElement) {
+    } else if (logging is Widget) {
       element.classes.add('render');
-      var renderer = new HtmlRenderer(element, context['jsPlumb']);
-      renderer.render(logging);
+      render(logging, element);
       logging.onUpdate.listen(([_]) async {
         await delay(0);
         if (logging is Visualization &&

--- a/test/serialization_test.dart
+++ b/test/serialization_test.dart
@@ -27,7 +27,7 @@ main() {
       expect(b.id, equals(a.id));
     });
     test("works for TextElement", () {
-      var a = new TextElement("abc");
+      var a = new TextWidget("abc");
       var b = remake(a);
       expect(b.text, equals(a.text));
     });
@@ -42,7 +42,7 @@ main() {
     });
     test("works for BlockGrid", () {
       var a = new BlockGrid.row([
-        new Block.pair(new TextElement("1")),
+        new Block.pair(new TextWidget("1")),
         new Block.vector(new Strike())
       ]);
       var b = remake(a);

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -16,31 +16,6 @@ body {
   padding: 0;
 }
 
-#corner {
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 100%;
-  z-index: 250;
-}
-
-#diagram{
-  float: right;
-  height:100%;
-  position:absolute;
-  top:0;
-  right: 0.75em;
-  z-index:200;
-  font-size: 0.92em;
-  font-family:$font-stack;
-  @include text;
-}
-
-#overlays {
-  position: relative;
-  width: 100%;
-}
-
 #turtle{
   position: absolute;
   right: 0;

--- a/web/index.html
+++ b/web/index.html
@@ -16,21 +16,7 @@
   <link rel="apple-touch-icon" sizes="192x192" href="assets/icons/xxxhdpi.png">
 </head>
 <body>
-<div id='corner'>
-  <div id='buttons'>
-  </div>
-  <div id='overlays'>
-    <div id='diagram'>
-      <table id='table'>
-        <tr id='row'>
-          <td id='frames'></td>
-          <td id='objects'></td>
-        </tr>
-      </table>
-    </div>
-    <canvas id='turtle' width='1000px' height='1000px'></canvas>
-  </div>
-</div>
+<canvas id='turtle' width='1000px' height='1000px'></canvas>
 <script src="main.dart.js"></script>
 </body>
 </html>

--- a/web/main.dart
+++ b/web/main.dart
@@ -39,8 +39,7 @@ Shift+Enter to add missing parens and run the current input
 main() async {
   String css = await HttpRequest.getString('assets/style.css');
   var style = querySelector('#theme');
-  var diagramBox = querySelector('#diagram');
-  var webLibrary = new WebLibrary(diagramBox, context['jsPlumb'], css, style);
+  var webLibrary = new WebLibrary(context['jsPlumb'], css, style);
   if (window.location.href.contains('logic')) {
     await startLogic(webLibrary);
   } else {
@@ -103,13 +102,13 @@ startScheme(WebLibrary webLibrary) async {
       'builtin-turtle': turtles.join(' ')
     })
   ]);
-  inter.logger(new MarkdownElement(motd, env: demos), true);
+  inter.logger(new MarkdownWidget(motd, env: demos), true);
 }
 
 addDemo(Frame env, String demoName, String code) {
   addPrimitive(env, new SchemeSymbol.runtime(demoName), (_, __) {
     var prompt = "<span class='repl-prompt'>scm></span> `$code`";
-    env.interpreter.logger(new MarkdownElement(prompt), true);
+    env.interpreter.logger(new MarkdownWidget(prompt), true);
     env.interpreter.run(code);
     return undefined;
   }, 0);
@@ -153,7 +152,7 @@ startLogic(WebLibrary webLibrary) {
   addTheme(themeInter, webLibrary, const SchemeSymbol('monochrome'));
   addTheme(themeInter, webLibrary, const SchemeSymbol('monochrome-dark'));
   addTheme(themeInter, webLibrary, const SchemeSymbol('go-bears'));
-  inter.logger(new MarkdownElement(logicMotd, env: themeInter.globalEnv), true);
+  inter.logger(new MarkdownWidget(logicMotd, env: themeInter.globalEnv), true);
 }
 
 addTheme(Interpreter inter, WebLibrary web, SchemeSymbol themeName) {


### PR DESCRIPTION
Closes #33.

Renames various properties, classes, and files:
`UIElement` -> `Widget`
`TextElement` -> `TextWidget`
`MarkdownElement` -> `MarkdownWidget`
`Expression.inlineUI` -> `Expression.inlineInDiagram`
`lib/src/core/ui.dart` -> `lib/src/core/widgets.dart`
`lib/src/web/html_ui.dart` -> `lib/src/web/renderer.dart`

This also eliminates the `render` Scheme built-in (it's been broken anyway) and the associated `Renderer` typedef that was a property of the Interpreter. The only thing that uses the HTML renderer (now a private class accessed with a `render` public method) is now the web REPL.

This is setup for a future refactoring of the UI of the overall app. I want to use "UI component" to refer to things like the web REPL, the input field (which will be refactored out of the REPL), the future editor, etc. I'll now use "rendering" and "widgets" when talking about the diagram elements. Widgets are Scheme Expressions; UI components will be Dart classes that aren't Scheme Expressions).