### PR TITLE
Fix bug in diagrammer

### DIFF
--- a/lib/src/core/widgets.dart
+++ b/lib/src/core/widgets.dart
@@ -162,13 +162,14 @@ class BlockGrid extends Widget {
     }
   }
 
-  BlockGrid toSpacer() => new BlockGrid(_grid
-      .map((row) => row.map((item) {
-            if (item is Anchor) return new TextMessage("x");
-            return item;
-          }).toList())
+  BlockGrid toSpacer() => BlockGrid(_grid
+      .map((row) => row
+          .map((item) => Block._(
+              item.type, item.inside is Anchor ? TextWidget("x") : item.inside))
+          .toList())
       .toList())
     ..spacer = true;
+
   toString() => "#$_grid";
 }
 


### PR DESCRIPTION
Found this while going through a more comprehensive code cleanup. That's not ready yet, but I think Dart 2 broke diagramming whenever spacers are used (so, whenever you have multi-row pair structures)