### PR TITLE
Refactors the code input box into a separate lib

### DIFF
--- a/lib/src/core/reader.dart
+++ b/lib/src/core/reader.dart
@@ -66,9 +66,11 @@ List nextCandidateToken(String line, int k) {
     } else if (_stringDelims.contains(c)) {
       String str = c;
       k++;
+      if (k >= line.length) throw FormatException("Invalid string $str");
       while (line[k] != '"') {
         if (line[k] == "\\") {
           k++;
+          if (k >= line.length) throw FormatException("Invalid string $str");
           str += "\\" + line[k];
         } else {
           str += line[k];

--- a/lib/src/core/utils.dart
+++ b/lib/src/core/utils.dart
@@ -1,5 +1,7 @@
 library cs61a_scheme.core.utils;
 
+import 'dart:async';
+
 import 'expressions.dart';
 import 'logging.dart';
 import 'procedures.dart';
@@ -91,3 +93,6 @@ int countParens(String text) {
       0, (val, token) => val + (token == const SchemeSymbol(')') ? 1 : 0));
   return left - right;
 }
+
+Future delay(int milliseconds) =>
+    Future.delayed(Duration(milliseconds: milliseconds));

--- a/lib/src/web/renderer.dart
+++ b/lib/src/web/renderer.dart
@@ -7,7 +7,7 @@ import 'dart:js';
 import 'package:markdown/markdown.dart' as md;
 
 import 'package:cs61a_scheme/cs61a_scheme_extra.dart';
-import 'package:cs61a_scheme/highlight.dart';
+import '../web_ui/highlight.dart';
 
 import 'web_library.dart';
 
@@ -143,7 +143,7 @@ class _Renderer {
       }
     }
     for (var code in element.querySelectorAll('code')) {
-      var styled = highlight(code.innerHtml);
+      var styled = highlightText(code.innerHtml);
       code.setInnerHtml(styled, validator: NodeValidatorBuilder.common());
     }
     element.classes.add('markdown');

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -1,0 +1,164 @@
+library web_ui.code_input;
+
+import 'dart:async';
+import 'dart:html';
+
+import 'package:cs61a_scheme/cs61a_scheme.dart';
+
+import 'highlight.dart';
+
+const List<SchemeSymbol> noIndentForms = [
+  SchemeSymbol("let"),
+  SchemeSymbol("define"),
+  SchemeSymbol("lambda"),
+  SchemeSymbol("define-macro")
+];
+
+class CodeInput {
+  Element element;
+  bool _active = true;
+  final List<StreamSubscription> _subs = [];
+
+  Function(String code) runCode;
+  Function(int parens) parenListener;
+
+  CodeInput(Element log, this.runCode, {this.parenListener}) {
+    element = SpanElement()
+      ..classes = ['code-input']
+      ..contentEditable = 'true';
+    _subs.add(element.onKeyPress.listen(_onInputKeyPress));
+    _subs.add(element.onKeyDown.listen(_keyListener));
+    _subs.add(element.onKeyUp.listen(_keyListener));
+    log.append(element);
+    element.focus();
+    parenListener ??= (_) => null;
+    parenListener(missingParens);
+  }
+
+  String get text => element.text;
+
+  set text(String newText) {
+    element.text = newText;
+    highlight(atEnd: true);
+  }
+
+  bool get active => _active;
+
+  int get missingParens => countParens(text);
+
+  void deactivate() {
+    _active = false;
+    element.contentEditable = 'false';
+    for (var sub in _subs) {
+      sub.cancel();
+    }
+  }
+
+  Future highlight(
+      {bool saveCursor = false, int cursor, bool atEnd = false}) async {
+    if (saveCursor) {
+      await highlightSaveCursor(element);
+    } else if (cursor != null) {
+      await highlightCustomCursor(element, cursor);
+    } else if (atEnd) {
+      await highlightAtEnd(element, element.text);
+    } else {
+      element.innerHtml = highlightText(element.text);
+    }
+  }
+
+  Future _onInputKeyPress(KeyboardEvent event) async {
+    if ((missingParens ?? -1) > 0 &&
+        event.shiftKey &&
+        event.keyCode == KeyCode.ENTER) {
+      event.preventDefault();
+      element.text = element.text.trimRight() + ')' * missingParens + '\n';
+      runCode(element.text);
+      await delay(100);
+      await highlight();
+    } else if ((missingParens ?? -1) == 0 && event.keyCode == KeyCode.ENTER) {
+      event.preventDefault();
+      element.text = element.text.trimRight() + '\n';
+      runCode(element.text);
+      await delay(100);
+      await highlight();
+    } else if ((missingParens ?? 0) > 0 && KeyCode.ENTER == event.keyCode) {
+      event.preventDefault();
+      int cursor = _currPosition();
+      String newInput = element.text;
+      String first = newInput.substring(0, cursor) + "\n";
+      String second = "";
+      if (cursor != newInput.length) {
+        second = newInput.substring(cursor);
+      }
+      int spaces = _countSpace(newInput, cursor);
+      element.text = first + " " * spaces + second;
+      await highlight(cursor: cursor + spaces + 1);
+    } else {
+      await delay(5);
+      await highlight(saveCursor: true);
+    }
+    parenListener(missingParens);
+  }
+
+  /// Determines how much space to indent the next line, based on parens
+  int _countSpace(String inputText, int position) {
+    List<String> splitLines = inputText.substring(0, position).split("\n");
+    // If the cursor is at the end of the line but not the end of the input, we
+    // must find that line and start counting parens from there
+    String refLine;
+    int totalMissingCount = 0;
+    for (refLine in splitLines.reversed) {
+      // Truncate to position of cursor when in middle of the line
+      totalMissingCount += countParens(refLine);
+      // Find the first line with an open paren but no close paren
+      if (totalMissingCount >= 1) break;
+    }
+    if (totalMissingCount == 0) {
+      return 0;
+    }
+    int strIndex = refLine.indexOf("(");
+    while (strIndex < (refLine.length - 1)) {
+      int nextClose = refLine.indexOf(")", strIndex + 1);
+      int nextOpen = refLine.indexOf("(", strIndex + 1);
+      // Find the open paren that corresponds to the missing closed paren
+      if (totalMissingCount > 1) {
+        totalMissingCount -= 1;
+      } else if (nextOpen == -1 || nextOpen < nextClose) {
+        Iterable<Expression> tokens = tokenizeLine(refLine.substring(strIndex));
+        Expression symbol = tokens.elementAt(1);
+        // Align subexpressions if any exist; otherwise, indent by two spaces
+        if (symbol == const SchemeSymbol("(")) {
+          return strIndex + 1;
+        } else if (noIndentForms.contains(symbol)) {
+          return strIndex + 2;
+        } else if (tokens.length > 2) {
+          return refLine.indexOf(tokens.elementAt(2).toString(), strIndex + 1);
+        } else if (nextOpen == -1) {
+          return strIndex + 2;
+        }
+      } else if (nextClose == -1) {
+        return strIndex + 2;
+      }
+      strIndex = nextOpen;
+    }
+    return strIndex + 2;
+  }
+
+  /// Returns the location in the input string where the cursor is
+  int _currPosition() =>
+      findPosition(element, window.getSelection().getRangeAt(0));
+
+  _keyListener(KeyboardEvent event) async {
+    int key = event.keyCode;
+    if (key == KeyCode.BACKSPACE) {
+      await delay(0);
+      parenListener(missingParens);
+      await highlight(saveCursor: true);
+    } else if (event.ctrlKey && (key == KeyCode.V || key == KeyCode.X)) {
+      await delay(0);
+      parenListener(missingParens);
+      await highlight(saveCursor: true);
+    }
+  }
+}

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -84,7 +84,7 @@ class CodeInput {
       await highlight();
     } else if ((missingParens ?? 0) > 0 && KeyCode.ENTER == event.keyCode) {
       event.preventDefault();
-      int cursor = _currPosition();
+      int cursor = findPosition(element, window.getSelection().getRangeAt(0));
       String newInput = element.text;
       String first = newInput.substring(0, cursor) + "\n";
       String second = "";
@@ -144,10 +144,6 @@ class CodeInput {
     }
     return strIndex + 2;
   }
-
-  /// Returns the location in the input string where the cursor is
-  int _currPosition() =>
-      findPosition(element, window.getSelection().getRangeAt(0));
 
   _keyListener(KeyboardEvent event) async {
     int key = event.keyCode;

--- a/lib/src/web_ui/highlight.dart
+++ b/lib/src/web_ui/highlight.dart
@@ -6,11 +6,11 @@ import 'dart:js';
 
 JsObject hljs = context['hljs'];
 
-String highlight(String code) =>
+String highlightText(String code) =>
     hljs.callMethod('highlight', ['scheme', code, true])['value'];
 
 Future highlightAtEnd(Element input, String code) async {
-  input.innerHtml = highlight(code);
+  input.innerHtml = highlightText(code);
   await Future.delayed(const Duration(milliseconds: 0));
   var selection = window.getSelection();
   var range = Range();
@@ -25,7 +25,7 @@ Future highlightSaveCursor(Element input) async {
   Selection selection = window.getSelection();
   Range last = selection.getRangeAt(0);
   int position = findPosition(input, last);
-  String styled = highlight(text);
+  String styled = highlightText(text);
   input.innerHtml = styled;
   Range range = _makeRange(input, position);
   selection.removeAllRanges();
@@ -35,7 +35,7 @@ Future highlightSaveCursor(Element input) async {
 Future highlightCustomCursor(Element input, int position) async {
   String text = input.text;
   Selection selection = window.getSelection();
-  String styled = highlight(text);
+  String styled = highlightText(text);
   input.innerHtml = styled;
   Range range = _makeRange(input, position);
   selection.removeAllRanges();

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -33,19 +33,6 @@ class Repl {
       if (!activeInput.element.contains(document.activeElement)) {
         activeInput.element.focus();
       }
-      /*if (activeInput.contains(e.target)) return;
-      await delay(0);
-      var selection = window.getSelection();
-      if (selection.rangeCount > 0) {
-        var range = window.getSelection().getRangeAt(0);
-        if (range.startOffset != range.endOffset) return;
-      }
-      activeInput.focus();
-      var range = Range();
-      range.selectNodeContents(activeInput);
-      range.collapse(false);
-      selection.removeAllRanges();
-      selection.addRange(range);*/
     });
     parent.append(container);
     status = SpanElement()..classes = ['repl-status'];

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -1,18 +1,19 @@
-library web_repl;
+library web_ui.repl;
 
-import 'dart:async';
 import 'dart:convert' show json;
 import 'dart:html';
 
 import 'package:cs61a_scheme/cs61a_scheme_web.dart';
-import 'package:cs61a_scheme/highlight.dart';
+
+import 'code_input.dart';
 
 class Repl {
   Element container;
   Element activeLoggingArea;
   Element activePrompt;
-  Element activeInput;
   Element status;
+
+  CodeInput activeInput;
 
   Interpreter interpreter;
 
@@ -20,13 +21,6 @@ class Repl {
   int historyIndex = -1;
 
   final String prompt;
-
-  List<SchemeSymbol> noIndent = [
-    const SchemeSymbol("let"),
-    const SchemeSymbol("define"),
-    const SchemeSymbol("lambda"),
-    const SchemeSymbol("define-macro")
-  ];
 
   Repl(this.interpreter, Element parent, {this.prompt = 'scm> '}) {
     if (window.localStorage.containsKey('#repl-history')) {
@@ -36,7 +30,10 @@ class Repl {
     addBuiltins();
     container = PreElement()..classes = ['repl'];
     container.onClick.listen((e) async {
-      if (activeInput.contains(e.target)) return;
+      if (!activeInput.element.contains(document.activeElement)) {
+        activeInput.element.focus();
+      }
+      /*if (activeInput.contains(e.target)) return;
       await delay(0);
       var selection = window.getSelection();
       if (selection.rangeCount > 0) {
@@ -48,7 +45,7 @@ class Repl {
       range.selectNodeContents(activeInput);
       range.collapse(false);
       selection.removeAllRanges();
-      selection.addRange(range);
+      selection.addRange(range);*/
     });
     parent.append(container);
     status = SpanElement()..classes = ['repl-status'];
@@ -80,6 +77,7 @@ class Repl {
         if (child == activePrompt) break;
         if (child != status) container.children.remove(child);
       }
+
       return undefined;
     }, 0);
     addBuiltin(env, const SchemeSymbol('autodraw'), (_a, _b) {
@@ -98,29 +96,19 @@ class Repl {
 
   buildNewInput() {
     activeLoggingArea = SpanElement();
-    if (activeInput != null) {
-      activeInput.contentEditable = 'false';
-      container.append(SpanElement()..text = '\n');
-    }
     container.append(activeLoggingArea);
+    if (activeInput != null) activeLoggingArea.text = "\n";
+    activeInput?.deactivate();
     activePrompt = SpanElement()
       ..text = prompt
       ..classes = ['repl-prompt'];
     container.append(activePrompt);
-    activeInput = SpanElement()
-      ..classes = ['repl-input']
-      ..contentEditable = 'true';
-    activeInput.onKeyPress.listen(onInputKeyPress);
-    activeInput.onKeyDown.listen(keyListener);
-    activeInput.onKeyUp.listen(keyListener);
-    container.append(activeInput);
-    activeInput.focus();
-    updateInputStatus();
+    activeInput =
+        CodeInput(container, runCode, parenListener: updateParenStatus);
     container.scrollTop = container.scrollHeight;
   }
 
-  runActiveCode() async {
-    var code = activeInput.text;
+  runCode(String code) async {
     addToHistory(code);
     buildNewInput();
     var tokens = tokenizeLines(code.split("\n")).toList();
@@ -171,16 +159,16 @@ class Repl {
 
   historyUp() {
     if (historyIndex < history.length - 1) {
-      replaceInput(history[++historyIndex]);
+      activeInput.text = history[++historyIndex];
     }
   }
 
   historyDown() {
     if (historyIndex > 0) {
-      replaceInput(history[--historyIndex]);
+      activeInput.text = history[--historyIndex];
     } else {
       historyIndex = -1;
-      replaceInput("");
+      activeInput.text = "";
     }
   }
 
@@ -196,59 +184,7 @@ class Repl {
     }
   }
 
-  keyListener(KeyboardEvent event) async {
-    int code = event.keyCode;
-    if (code == KeyCode.BACKSPACE) {
-      //this should be changed to call highlightSaveCursor
-      //once the bug with newlines is fixed
-      await delay(0);
-      updateInputStatus();
-    } else if (event.ctrlKey && (code == KeyCode.V || code == KeyCode.X)) {
-      await delay(0);
-      updateInputStatus();
-      await highlightSaveCursor(activeInput);
-    }
-  }
-
-  onInputKeyPress(KeyboardEvent event) async {
-    Element input = activeInput;
-    int missingParens = updateInputStatus();
-    if ((missingParens ?? -1) > 0 &&
-        event.shiftKey &&
-        event.keyCode == KeyCode.ENTER) {
-      event.preventDefault();
-      activeInput.text =
-          activeInput.text.trimRight() + ')' * missingParens + '\n';
-      runActiveCode();
-      await delay(100);
-      input.innerHtml = highlight(input.text);
-    } else if ((missingParens ?? -1) == 0 && event.keyCode == KeyCode.ENTER) {
-      event.preventDefault();
-      activeInput.text = activeInput.text.trimRight() + '\n';
-      runActiveCode();
-      await delay(100);
-      input.innerHtml = highlight(input.text);
-    } else if ((missingParens ?? 0) > 0 && KeyCode.ENTER == event.keyCode) {
-      event.preventDefault();
-      int cursor = _currPosition();
-      String newInput = input.text;
-      String first = newInput.substring(0, cursor) + "\n";
-      String second = "";
-      if (cursor != newInput.length) {
-        second = newInput.substring(cursor);
-      }
-      int spaces = _countSpace(newInput, cursor);
-      input.text = first + " " * spaces + second;
-      await highlightCustomCursor(input, cursor + spaces + 1);
-    } else {
-      await delay(5);
-      await highlightSaveCursor(input);
-    }
-    updateInputStatus();
-  }
-
-  int updateInputStatus() {
-    int missingParens = countParens(activeInput.text);
+  updateParenStatus(int missingParens) {
     if (missingParens == null) {
       status.classes = ['repl-status', 'error'];
       status.text = 'Invalid syntax!';
@@ -263,12 +199,6 @@ class Repl {
       status.classes = ['repl-status'];
       status.text = "";
     }
-    return missingParens;
-  }
-
-  replaceInput(String text) async {
-    await highlightAtEnd(activeInput, text);
-    updateInputStatus();
   }
 
   logInto(Element element, Expression logging, [bool newline = true]) {
@@ -314,59 +244,4 @@ class Repl {
     activeLoggingArea.appendText(text);
     container.scrollTop = container.scrollHeight;
   }
-
-  Future delay(int milliseconds) =>
-      Future.delayed(Duration(milliseconds: milliseconds));
-
-  ///Returns how many spaces the next line must be indented based
-  ///on the line with the last open parentheses
-  int _countSpace(String inputText, int position) {
-    List<String> splitLines = inputText.substring(0, position).split("\n");
-    //if the cursor is at the end of a line but not at the end of the whole input
-    //must find that line and start counting parens from there on
-    String refLine;
-    int totalMissingCount = 0;
-    for (refLine in splitLines.reversed) {
-      //if the cursor is in the middle of the line, truncate to the position of the cursor
-      totalMissingCount += countParens(refLine);
-      //find the first line where there exists an open parens
-      //with no closed parens
-      if (totalMissingCount >= 1) break;
-    }
-    if (totalMissingCount == 0) {
-      return 0;
-    }
-    int strIndex = refLine.indexOf("(");
-    while (strIndex < (refLine.length - 1)) {
-      int nextClose = refLine.indexOf(")", strIndex + 1);
-      int nextOpen = refLine.indexOf("(", strIndex + 1);
-      //find the location of the open parens that
-      //corresponds to the missing closed parnes
-      if (totalMissingCount > 1) {
-        totalMissingCount -= 1;
-      } else if (nextOpen == -1 || nextOpen < nextClose) {
-        Iterable<Expression> tokens = tokenizeLine(refLine.substring(strIndex));
-        Expression symbol = tokens.elementAt(1);
-        //decide whether to align with subexpressions if they exist
-        //otherwise indent by two spaces
-        if (symbol == const SchemeSymbol("(")) {
-          return strIndex + 1;
-        } else if (noIndent.contains(symbol)) {
-          return strIndex + 2;
-        } else if (tokens.length > 2) {
-          return refLine.indexOf(tokens.elementAt(2).toString(), strIndex + 1);
-        } else if (nextOpen == -1) {
-          return strIndex + 2;
-        }
-      } else if (nextClose == -1) {
-        return strIndex + 2;
-      }
-      strIndex = nextOpen;
-    }
-    return strIndex + 2;
-  }
-
-  /// Returns the location in the input string where the cursor is
-  int _currPosition() =>
-      findPosition(activeInput, window.getSelection().getRangeAt(0));
 }

--- a/lib/web_ui.dart
+++ b/lib/web_ui.dart
@@ -1,0 +1,1 @@
+export 'src/web_ui/repl.dart';

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -72,10 +72,6 @@ body {
     @include prompt;
   }
 
-  .repl-input {
-    display: inline-block;
-  }
-
   .repl-async {
     @include async-log;
   }
@@ -103,10 +99,14 @@ body {
   .error {
     @include error;
   }
+}
+
+.code-input {
+  display: inline-block;
+}
   
-  .repl-input:focus {
-    outline: none;
-  }
+.code-input:focus {
+  outline: none;
 }
 
 .hljs-builtin-normal { @include spec-keyword; }

--- a/web/main.dart
+++ b/web/main.dart
@@ -4,7 +4,7 @@ import 'dart:js';
 import 'package:cs61a_scheme/cs61a_scheme_web.dart';
 import 'package:cs61a_scheme_impl/impl.dart' show StaffProjectImplementation;
 
-import 'package:cs61a_scheme/web_repl.dart';
+import 'package:cs61a_scheme/web_ui.dart';
 
 const String motd = "**61A Scheme Web Interpreter 2.0.0-beta**"
     "                         <small>"


### PR DESCRIPTION
This changes the web UI to now have its own directory of libraries. The web REPL and the highlighter are both in that directory, and the code input box is now refactored into its own library.

The ultimate goal here is to use the code input box as a component in both the REPL and the (to be written) editor.

This refactor was largely limited to the input box, but I also plan to move some of the diagram rendering code and some of the setup code in `web/main.dart` into `web_ui` libraries.

Along the way, I cleaned up some of the code in both the code input box and the rest of the REPL. I think this refactor somehow fixed the bug with highlighting on backspace (see discussion in #50), so that's enabled again.

@dnachum: since this deals a lot with the input box stuff that you've worked on, can you review this when you get the chance?