### PR TITLE
Refactors the library builder

### DIFF
--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -21,22 +21,18 @@ String generateImportMixin(String sourceCode) {
 }
 
 String _buildMixin(ClassDeclaration decl) {
-  List<String> builtins = [];
+  List<BuiltinStub> builtins = [];
   List<String> abstractMethods = [];
-  bool myNeedsTurtle = false;
   for (ClassMember member in decl.members) {
     if (member is MethodDeclaration) {
       String name = member.name.toSource();
       if (!name.startsWith('import') && !name.startsWith('_')) {
-        needsTurtle = false;
         abstractMethods.add(_buildAbstract(member));
-        builtins.add(_buildBuiltin(member));
-        myNeedsTurtle = myNeedsTurtle || needsTurtle;
+        builtins.add(_buildStub(member));
       }
     }
   }
-  needsTurtle = false;
-  if (myNeedsTurtle) {
+  if (builtins.any((stub) => stub.needsTurtle)) {
     abstractMethods.add('Turtle get turtle;');
   }
   String mixinName = decl.withClause.mixinTypes[0].name.toSource();
@@ -55,149 +51,214 @@ abstract class $mixinName {
 String _buildAbstract(MethodDeclaration method) =>
     "${method.returnType} ${method.name}${method.parameters};";
 
-bool needsTurtle = false;
+class BuiltinStub {
+  String methodName;
+  String name;
+  List<String> aliases = [];
+  int minArgs = 0, maxArgs = -1;
+  bool variableArity = false;
 
-String _buildBuiltin(MethodDeclaration method) {
-  String name = json.encode(method.name.toSource().toLowerCase());
-  bool setName = false;
-  List<String> extraNames = [];
-  bool variable = false;
-  String minArgs = "0", maxArgs = "-1";
-  String returning = 'return';
-  String after = ";";
-  String op = "";
-  String before = "";
-  for (Annotation ant in method.metadata) {
-    if (ant.name.toSource() == "MinArgs") {
-      minArgs = ant.arguments.arguments[0].toSource();
-      variable = true;
-    } else if (ant.name.toSource() == "MaxArgs") {
-      maxArgs = ant.arguments.arguments[0].toSource();
-      variable = true;
-    } else if (ant.name.toSource() == "SchemeSymbol") {
-      if (!setName) {
-        name = ant.arguments.arguments[0].toSource().toLowerCase();
-        setName = true;
+  List<String> events = [];
+  bool operandProcedure = false;
+  bool needsTurtle = false;
+
+  String returnType;
+  List<String> paramTypes;
+  bool needsEnvironment = false;
+
+  String get symbol => 'const SchemeSymbol($name)';
+
+  toString() {
+    var fn = _makeFunction();
+    var extra = aliases
+        .map((alias) => 'const SchemeSymbol($alias)')
+        .map((alias) => '__env.bindings[$alias] = __env.bindings[$symbol];'
+            '__env.hidden[$alias] = true;')
+        .join('');
+    var op = operandProcedure ? "Operand" : "";
+    var arity = variableArity ? "Variable" : "";
+    var args = variableArity ? "$minArgs, $maxArgs" : "$minArgs";
+    return "add$arity${op}Builtin(__env, $symbol, $fn, $args);$extra";
+  }
+
+  String _makeFunction() {
+    if (variableArity &&
+        needsEnvironment &&
+        !returnConversions.containsKey(returnType) &&
+        returnType != 'void') return "this.$methodName";
+    String before = needsTurtle ? "turtle.show();" : "";
+    String after = "";
+    String prefix = "return";
+    for (var event in events) {
+      if (returnType == 'void') {
+        after += "__env.interpreter.triggerEvent($event, [undefined], __env);";
       } else {
-        extraNames.add(ant.arguments.arguments[0].toSource().toLowerCase());
+        prefix = "var __value =";
+        after += "__env.interpreter.triggerEvent($event, [__value], __env);";
       }
-    } else if (ant.name.toSource() == "TriggerEventAfter") {
-      String symbol = ant.arguments.arguments[0].toSource();
-      returning = 'var __value =';
-      after += " __env.interpreter.triggerEvent($symbol, [__value], __env);";
-    } else if (ant.name.toSource() == "noeval") {
-      op = "Operand";
-    } else if (ant.name.toSource() == 'turtlestart') {
-      needsTurtle = true;
-      before += 'turtle.show();';
+    }
+    if (returnType == 'void') {
+      prefix = "";
+      after += "return undefined;";
+    }
+    String checks = _makeChecks();
+    String call = "this.$methodName(${_makeParams()})";
+    call = _wrapReturn(call);
+    return "(__exprs, __env) {$checks $before $prefix $call; $after}";
+  }
+
+  String _makeChecks() {
+    if (variableArity) return "";
+    var checks = [];
+    for (int i = 0; i < paramTypes.length; i++) {
+      var type = paramTypes[i];
+      if (typeChecks.containsKey(paramTypes[i])) {
+        type = typeChecks[type];
+      }
+      if (type != 'Expression') checks.add("__exprs[$i] is! $type");
+    }
+    if (checks.isEmpty) return "";
+    var decodeName = name.substring(1, name.length - 1);
+    var error = "Argument of invalid type passed to $decodeName.";
+    return "if(${checks.join('||')}) throw SchemeException('$error');";
+  }
+
+  String _makeParams() {
+    if (variableArity) return needsEnvironment ? "__exprs, __env" : "__exprs";
+    var params = [];
+    for (int i = 0; i < paramTypes.length; i++) {
+      var param = '__exprs[$i]';
+      switch (paramTypes[i]) {
+        case 'int':
+          param = '$param.toJS().toInt()';
+          break;
+        case 'double':
+          param = '$param.toJS().toDouble()';
+          break;
+        case 'num':
+          param = '$param.toJS()';
+          break;
+        case 'bool':
+          param = '$param.isTruthy';
+          break;
+        case 'String':
+          param = '($param as SchemeString).value';
+          break;
+      }
+      params.add(param);
+    }
+    if (needsEnvironment) params.add("__env");
+    return params.join(',');
+  }
+
+  String _wrapReturn(String call) {
+    if (returnConversions.containsKey(returnType)) {
+      return '${returnConversions[returnType]}($call)';
+    }
+    return call;
+  }
+
+  static const Map<String, String> typeChecks = {
+    'int': 'Integer',
+    'double': 'Double',
+    'num': 'Number',
+    'bool': 'Boolean',
+    'String': 'SchemeString'
+  };
+
+  static const Map<String, String> returnConversions = {
+    'int': 'Number.fromInt',
+    'double': 'Number.fromDouble',
+    'num': 'Number.fromNum',
+    'String': 'SchemeString',
+    'bool': 'Boolean',
+    'Future<Expression>': 'AsyncExpression',
+    'JsFunction': 'JsProcedure',
+    'JsObject': 'JsExpression'
+  };
+}
+
+BuiltinStub _buildStub(MethodDeclaration method) {
+  var stub = BuiltinStub();
+  stub.methodName = method.name.toSource();
+  String arg(Annotation ant) => ant.arguments.arguments[0].toSource();
+  for (Annotation ant in method.metadata) {
+    switch (ant.name.toSource()) {
+      case "MinArgs":
+        stub.minArgs = int.parse(arg(ant));
+        stub.variableArity = true;
+        break;
+      case "MaxArgs":
+        stub.maxArgs = int.parse(arg(ant));
+        stub.variableArity = true;
+        break;
+      case "SchemeSymbol":
+        if (stub.name == null) {
+          stub.name = arg(ant).toLowerCase();
+        } else {
+          stub.aliases.add(arg(ant).toLowerCase());
+        }
+        break;
+      case "TriggerEventAfter":
+        stub.events.add(arg(ant));
+        break;
+      case "noeval":
+        stub.operandProcedure = true;
+        break;
+      case "turtlestart":
+        stub.needsTurtle = true;
+        break;
     }
   }
-  String returnType = method.returnType.toSource();
-  if (returnType == 'void') {
-    returning = 'var __value = undefined; ';
-    after += ' return __value;';
-  } else if (returnType == 'int') {
-    returning += ' Number.fromInt(';
-    after = ')' + after;
-  } else if (returnType == 'double') {
-    returning += ' Number.fromDouble(';
-    after = ')' + after;
-  } else if (returnType == 'num') {
-    returning += ' Number.fromNum(';
-    after = ')' + after;
-  } else if (returnType == 'String') {
-    returning += ' SchemeString(';
-    after = ')' + after;
-  } else if (returnType == 'bool') {
-    returning += ' Boolean(';
-    after = ')' + after;
-  } else if (returnType == 'Future<Expression>') {
-    returning += ' AsyncExpression(';
-    after = ')' + after;
-  } else if (returnType == 'JsFunction') {
-    returning += ' JsProcedure(';
-    after = ')' + after;
-  } else if (returnType == 'JsObject') {
-    returning += ' JsExpression(';
-    after = ')' + after;
+  stub.name ??= json.encode(method.name.toSource().toLowerCase());
+  stub.returnType = method.returnType.toSource();
+  bool takesListExpr = _isVariableArity(method);
+  if (stub.variableArity && !takesListExpr) {
+    throw Exception("Built-ins with fixed arguments can have min/max");
   }
+  stub.variableArity = takesListExpr;
+  if (stub.variableArity) {
+    int paramCount = method.parameters.parameters.length;
+    if (paramCount != 1 && paramCount != 2) {
+      throw Exception("${stub.name} has an invalid number of parameters!");
+    }
+    stub.needsEnvironment = paramCount == 2;
+  } else {
+    stub.paramTypes = _paramTypes(method);
+    stub.needsEnvironment =
+        stub.paramTypes.isNotEmpty && stub.paramTypes.last == "Frame";
+    if (stub.needsEnvironment) stub.paramTypes.removeLast();
+    stub.minArgs = stub.paramTypes.length;
+    stub.maxArgs = stub.paramTypes.length;
+  }
+  return stub;
+}
+
+List<String> _paramTypes(MethodDeclaration method) {
+  List<String> types = [];
+  for (FormalParameter param in method.parameters.parameters) {
+    if (param is SimpleFormalParameter) {
+      if (param.type == null) {
+        throw Exception("Built-in procedure parameters must be typed.");
+      }
+      types.add(param.type.toSource());
+    } else {
+      throw Exception("Built-in procedures may not have optional parameters");
+    }
+  }
+  return types;
+}
+
+bool _isVariableArity(MethodDeclaration method) {
   if (method.parameters.parameters.isNotEmpty) {
     FormalParameter param = method.parameters.parameters[0];
     if (param is SimpleFormalParameter) {
       if (param.type.toSource() == "List<Expression>") {
-        variable = true;
+        return true;
       }
     } else {
       throw Exception("Built-in procedures may not have optional parameters.");
     }
   }
-  String symb = "const SchemeSymbol($name)";
-  var extraSymbs = extraNames.map((name) => "const SchemeSymbol($name)");
-  String extra = "";
-  for (String symbol in extraSymbs) {
-    extra += '__env.bindings[$symbol] = __env.bindings[$symb];';
-    extra += '__env.hidden[$symbol] = true;';
-  }
-  if (variable) {
-    String fn = "this." + method.name.toSource();
-    int paramCount = method.parameters.parameters.length;
-    if (paramCount != 1 && paramCount != 2) {
-      throw Exception("$fn has an invalid number of parameters!");
-    }
-    if (after != "") {
-      String args = paramCount == 1 ? '__exprs' : '__exprs, __env';
-      fn = "(__exprs, __env) {$before$returning $fn($args)$after}";
-    } else if (paramCount == 1) {
-      fn = "(__exprs, __env) {$before$returning $fn(__exprs)$after}";
-    }
-    return "addVariable${op}Builtin(__env, $symb, $fn, $minArgs, $maxArgs);$extra";
-  } else {
-    List<String> types = [];
-    for (FormalParameter param in method.parameters.parameters) {
-      if (param is SimpleFormalParameter) {
-        if (param.type == null) {
-          throw Exception("Built-in procedure parameters must be typed.");
-        }
-        types.add(param.type.toSource());
-      } else {
-        throw Exception("Built-in procedures may not have optional parameters");
-      }
-    }
-    bool takesFrame = types.isNotEmpty && types.last == "Frame";
-    if (takesFrame) types.removeLast();
-    String checks = "";
-    var passes = [];
-    var pieces = [];
-    for (int i = 0; i < types.length; i++) {
-      if (types[i] == 'int') {
-        pieces.add("__exprs[$i] is! Integer");
-        passes.add("__exprs[$i].toJS().toInt()");
-      } else if (types[i] == 'double') {
-        pieces.add("__exprs[$i] is! Double");
-        passes.add("__exprs[$i].toJS().toDouble()");
-      } else if (types[i] == 'num') {
-        pieces.add("__exprs[$i] is! Number");
-        passes.add("__exprs[$i].toJS()");
-      } else if (types[i] == 'bool') {
-        pieces.add("__exprs[$i] is! Boolean");
-        passes.add("__exprs[$i].isTruthy");
-      } else if (types[i] == 'String') {
-        pieces.add("__exprs[$i] is! SchemeString");
-        passes.add("(__exprs[$i] as SchemeString).value");
-      } else {
-        pieces.add("__exprs[$i] is! ${types[i]}");
-        passes.add("__exprs[$i]");
-      }
-    }
-    if (types.any((type) => type != "Expression")) {
-      var decodeName = name.substring(1, name.length - 1);
-      var error = "Argument of invalid type passed to $decodeName.";
-      checks = "if(${pieces.join('||')}) throw SchemeException('$error');";
-    }
-    if (takesFrame) passes.add("__env");
-    var passStr = passes.join(",");
-    var m = "this." + method.name.toSource();
-    var fn = "(__exprs, __env){$checks $before $returning $m($passStr)$after }";
-    return "add${op}Builtin(__env, $symb, $fn, ${types.length});$extra";
-  }
+  return false;
 }

--- a/lib/src/core/standard_library.g.dart
+++ b/lib/src/core/standard_library.g.dart
@@ -66,9 +66,8 @@ abstract class _$StandardLibraryMixin {
       return this.apply(__exprs[0], __exprs[1], __env);
     }, 2);
     addBuiltin(__env, const SchemeSymbol("display"), (__exprs, __env) {
-      var __value = undefined;
       this.display(__exprs[0], __env);
-      return __value;
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol("error"), (__exprs, __env) {
       return this.error(__exprs[0]);
@@ -86,14 +85,12 @@ abstract class _$StandardLibraryMixin {
       return this.load(__exprs[0], __env);
     }, 1);
     addBuiltin(__env, const SchemeSymbol("newline"), (__exprs, __env) {
-      var __value = undefined;
       this.newline(__env);
-      return __value;
+      return undefined;
     }, 0);
     addBuiltin(__env, const SchemeSymbol("print"), (__exprs, __env) {
-      var __value = undefined;
       this.print(__exprs[0], __env);
-      return __value;
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol("atom?"), (__exprs, __env) {
       return Boolean(this.isAtom(__exprs[0]));
@@ -261,22 +258,20 @@ abstract class _$StandardLibraryMixin {
       return this.cdrStream(__exprs[0]);
     }, 1);
     addBuiltin(__env, const SchemeSymbol("set-car!"), (__exprs, __env) {
-      if (__exprs[0] is! Pair || __exprs[1] is! Expression)
+      if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to set-car!.');
-      var __value = undefined;
       this.setCar(__exprs[0], __exprs[1]);
-      __env.interpreter
-          .triggerEvent(const SchemeSymbol("pair-mutation"), [__value], __env);
-      return __value;
+      __env.interpreter.triggerEvent(
+          const SchemeSymbol("pair-mutation"), [undefined], __env);
+      return undefined;
     }, 2);
     addBuiltin(__env, const SchemeSymbol("set-cdr!"), (__exprs, __env) {
-      if (__exprs[0] is! Pair || __exprs[1] is! Expression)
+      if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to set-cdr!.');
-      var __value = undefined;
       this.setCdr(__exprs[0], __exprs[1]);
-      __env.interpreter
-          .triggerEvent(const SchemeSymbol("pair-mutation"), [__value], __env);
-      return __value;
+      __env.interpreter.triggerEvent(
+          const SchemeSymbol("pair-mutation"), [undefined], __env);
+      return undefined;
     }, 2);
     addBuiltin(__env, const SchemeSymbol("call/cc"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -43,18 +43,15 @@ abstract class _$ExtraLibraryMixin {
     addBuiltin(__env, const SchemeSymbol("diagram"), (__exprs, __env) {
       return this.diagram(__env);
     }, 0);
-    addVariableOperandBuiltin(__env, const SchemeSymbol("visualize"),
-        (__exprs, __env) {
-      return this.visualize(__exprs, __env);
-    }, 0, -1);
+    addVariableOperandBuiltin(
+        __env, const SchemeSymbol("visualize"), this.visualize, 0, -1);
     addBuiltin(__env, const SchemeSymbol("bindings"), (__exprs, __env) {
       return this.bindings(__env);
     }, 0);
     addVariableBuiltin(__env, const SchemeSymbol('trigger-event'),
         (__exprs, __env) {
-      var __value = undefined;
       this.triggerEvent(__exprs, __env);
-      return __value;
+      return undefined;
     }, 1, -1);
     addBuiltin(__env, const SchemeSymbol('listen-for'), (__exprs, __env) {
       if (__exprs[0] is! SchemeSymbol || __exprs[1] is! Procedure)
@@ -65,16 +62,14 @@ abstract class _$ExtraLibraryMixin {
       if (__exprs[0] is! SchemeEventListener)
         throw SchemeException(
             'Argument of invalid type passed to cancel-listener.');
-      var __value = undefined;
       this.cancelListener(__exprs[0], __env);
-      return __value;
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol('cancel-all'), (__exprs, __env) {
       if (__exprs[0] is! SchemeSymbol)
         throw SchemeException('Argument of invalid type passed to cancel-all.');
-      var __value = undefined;
       this.cancelAll(__exprs[0], __env);
-      return __value;
+      return undefined;
     }, 1);
     addVariableBuiltin(__env, const SchemeSymbol('string-append'),
         (__exprs, __env) {
@@ -91,14 +86,11 @@ abstract class _$ExtraLibraryMixin {
             'Argument of invalid type passed to deserialize.');
       return this.deserialize((__exprs[0] as SchemeString).value);
     }, 1);
-    addVariableBuiltin(__env, const SchemeSymbol("formatted"),
-        (__exprs, __env) {
-      return this.formatted(__exprs, __env);
-    }, 0, -1);
+    addVariableBuiltin(
+        __env, const SchemeSymbol("formatted"), this.formatted, 0, -1);
     addBuiltin(__env, const SchemeSymbol('logic'), (__exprs, __env) {
-      var __value = undefined;
       this.logicStart(__env);
-      return __value;
+      return undefined;
     }, 0);
   }
 }

--- a/lib/src/extra/logic_library.g.dart
+++ b/lib/src/extra/logic_library.g.dart
@@ -12,27 +12,24 @@ abstract class _$LogicLibraryMixin {
   void importAll(Frame __env) {
     addVariableOperandBuiltin(__env, const SchemeSymbol('fact'),
         (__exprs, __env) {
-      var __value = undefined;
       this.fact(__exprs);
-      return __value;
+      return undefined;
     }, 0, -1);
     __env.bindings[const SchemeSymbol('!')] =
         __env.bindings[const SchemeSymbol('fact')];
     __env.hidden[const SchemeSymbol('!')] = true;
     addVariableOperandBuiltin(__env, const SchemeSymbol('query'),
         (__exprs, __env) {
-      var __value = undefined;
       this.query(__exprs, __env);
-      return __value;
+      return undefined;
     }, 0, -1);
     __env.bindings[const SchemeSymbol('?')] =
         __env.bindings[const SchemeSymbol('query')];
     __env.hidden[const SchemeSymbol('?')] = true;
     addVariableOperandBuiltin(__env, const SchemeSymbol('query-one'),
         (__exprs, __env) {
-      var __value = undefined;
       this.queryOne(__exprs, __env);
-      return __value;
+      return undefined;
     }, 0, -1);
     addBuiltin(__env, const SchemeSymbol('prolog'), (__exprs, __env) {
       return SchemeString(this.prolog());

--- a/lib/src/web/turtle_library.g.dart
+++ b/lib/src/web/turtle_library.g.dart
@@ -36,9 +36,8 @@ abstract class _$TurtleLibraryMixin {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to forward.');
       turtle.show();
-      var __value = undefined;
       this.forward(__exprs[0].toJS());
-      return __value;
+      return undefined;
     }, 1);
     __env.bindings[const SchemeSymbol('fd')] =
         __env.bindings[const SchemeSymbol('forward')];
@@ -47,9 +46,8 @@ abstract class _$TurtleLibraryMixin {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to backward.');
       turtle.show();
-      var __value = undefined;
       this.backward(__exprs[0].toJS());
-      return __value;
+      return undefined;
     }, 1);
     __env.bindings[const SchemeSymbol('back')] =
         __env.bindings[const SchemeSymbol('backward')];
@@ -61,9 +59,8 @@ abstract class _$TurtleLibraryMixin {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to left.');
       turtle.show();
-      var __value = undefined;
       this.left(__exprs[0].toJS());
-      return __value;
+      return undefined;
     }, 1);
     __env.bindings[const SchemeSymbol('lt')] =
         __env.bindings[const SchemeSymbol('left')];
@@ -72,27 +69,24 @@ abstract class _$TurtleLibraryMixin {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to right.');
       turtle.show();
-      var __value = undefined;
       this.right(__exprs[0].toJS());
-      return __value;
+      return undefined;
     }, 1);
     __env.bindings[const SchemeSymbol('rt')] =
         __env.bindings[const SchemeSymbol('right')];
     __env.hidden[const SchemeSymbol('rt')] = true;
     addVariableBuiltin(__env, const SchemeSymbol("circle"), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.circle(__exprs);
-      return __value;
+      return undefined;
     }, 1, 2);
     addBuiltin(__env, const SchemeSymbol('setposition'), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException(
             'Argument of invalid type passed to setposition.');
       turtle.show();
-      var __value = undefined;
       this.setPosition(__exprs[0].toJS(), __exprs[1].toJS());
-      return __value;
+      return undefined;
     }, 2);
     __env.bindings[const SchemeSymbol('setpos')] =
         __env.bindings[const SchemeSymbol('setposition')];
@@ -104,122 +98,104 @@ abstract class _$TurtleLibraryMixin {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to setheading.');
       turtle.show();
-      var __value = undefined;
       this.setHeading(__exprs[0].toJS());
-      return __value;
+      return undefined;
     }, 1);
     __env.bindings[const SchemeSymbol('seth')] =
         __env.bindings[const SchemeSymbol('setheading')];
     __env.hidden[const SchemeSymbol('seth')] = true;
     addBuiltin(__env, const SchemeSymbol('penup'), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.penUp();
-      return __value;
+      return undefined;
     }, 0);
     __env.bindings[const SchemeSymbol('pu')] =
         __env.bindings[const SchemeSymbol('penup')];
     __env.hidden[const SchemeSymbol('pu')] = true;
     addBuiltin(__env, const SchemeSymbol('pendown'), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.penDown();
-      return __value;
+      return undefined;
     }, 0);
     __env.bindings[const SchemeSymbol('pd')] =
         __env.bindings[const SchemeSymbol('pendown')];
     __env.hidden[const SchemeSymbol('pd')] = true;
     addBuiltin(__env, const SchemeSymbol('turtle-clear'), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.turtleClear();
-      return __value;
+      return undefined;
     }, 0);
     addBuiltin(__env, const SchemeSymbol("color"), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.color(__exprs[0]);
-      return __value;
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol('begin_fill'), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.beginFill();
-      return __value;
+      return undefined;
     }, 0);
     __env.bindings[const SchemeSymbol('begin-fill')] =
         __env.bindings[const SchemeSymbol('begin_fill')];
     __env.hidden[const SchemeSymbol('begin-fill')] = true;
     addBuiltin(__env, const SchemeSymbol('end_fill'), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.endFill();
-      return __value;
+      return undefined;
     }, 0);
     __env.bindings[const SchemeSymbol('end-fill')] =
         __env.bindings[const SchemeSymbol('end_fill')];
     __env.hidden[const SchemeSymbol('end-fill')] = true;
     addBuiltin(__env, const SchemeSymbol("exitonclick"), (__exprs, __env) {
-      var __value = undefined;
       this.exitonclick(__env);
-      return __value;
+      return undefined;
     }, 0);
     addBuiltin(__env, const SchemeSymbol('turtle-exit'), (__exprs, __env) {
-      var __value = undefined;
       this.exit();
-      return __value;
+      return undefined;
     }, 0);
     addBuiltin(__env, const SchemeSymbol("bgcolor"), (__exprs, __env) {
       turtle.show();
-      var __value = undefined;
       this.bgcolor(__exprs[0]);
-      return __value;
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol("pensize"), (__exprs, __env) {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to pensize.');
       turtle.show();
-      var __value = undefined;
       this.pensize(__exprs[0].toJS());
-      return __value;
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol("help"), (__exprs, __env) {
-      var __value = undefined;
       this.help(__env);
-      return __value;
+      return undefined;
     }, 0);
     addBuiltin(__env, const SchemeSymbol('turtle-grid'), (__exprs, __env) {
       if (__exprs[0] is! Integer || __exprs[1] is! Integer)
         throw SchemeException(
             'Argument of invalid type passed to turtle-grid.');
-      var __value = undefined;
       this.setGridSize(__exprs[0].toJS().toInt(), __exprs[1].toJS().toInt());
-      return __value;
+      return undefined;
     }, 2);
     addBuiltin(__env, const SchemeSymbol('turtle-canvas'), (__exprs, __env) {
       if (__exprs[0] is! Integer || __exprs[1] is! Integer)
         throw SchemeException(
             'Argument of invalid type passed to turtle-canvas.');
-      var __value = undefined;
       this.setCanvasSize(__exprs[0].toJS().toInt(), __exprs[1].toJS().toInt());
-      return __value;
+      return undefined;
     }, 2);
     addBuiltin(__env, const SchemeSymbol("pixel"), (__exprs, __env) {
-      if (__exprs[0] is! Number ||
-          __exprs[1] is! Number ||
-          __exprs[2] is! Expression)
+      if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to pixel.');
       turtle.show();
-      var __value = undefined;
       this.pixel(__exprs[0].toJS(), __exprs[1].toJS(), __exprs[2]);
-      return __value;
+      return undefined;
     }, 3);
     addBuiltin(__env, const SchemeSymbol("pixelsize"), (__exprs, __env) {
       if (__exprs[0] is! Integer)
         throw SchemeException('Argument of invalid type passed to pixelsize.');
-      var __value = undefined;
       this.pixelsize(__exprs[0].toJS().toInt());
-      return __value;
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol('screen_width'), (__exprs, __env) {
       return Number.fromNum(this.screenWidth());
@@ -235,9 +211,8 @@ abstract class _$TurtleLibraryMixin {
     __env.hidden[const SchemeSymbol('screen-height')] = true;
     addVariableBuiltin(__env, const SchemeSymbol('unsupported'),
         (__exprs, __env) {
-      var __value = undefined;
       this.unsupported(__exprs, __env);
-      return __value;
+      return undefined;
     }, 0, -1);
     __env.bindings[const SchemeSymbol('speed')] =
         __env.bindings[const SchemeSymbol('unsupported')];

--- a/lib/src/web/web_library.g.dart
+++ b/lib/src/web/web_library.g.dart
@@ -33,14 +33,12 @@ abstract class _$WebLibraryMixin {
       return this.jsContext();
     }, 0);
     addBuiltin(__env, const SchemeSymbol("js-set!"), (__exprs, __env) {
-      if (__exprs[0] is! JsExpression ||
-          __exprs[1] is! Expression ||
-          __exprs[2] is! Expression)
+      if (__exprs[0] is! JsExpression)
         throw SchemeException('Argument of invalid type passed to js-set!.');
       return this.jsSet(__exprs[0], __exprs[1], __exprs[2]);
     }, 3);
     addBuiltin(__env, const SchemeSymbol("js-ref"), (__exprs, __env) {
-      if (__exprs[0] is! JsExpression || __exprs[1] is! Expression)
+      if (__exprs[0] is! JsExpression)
         throw SchemeException('Argument of invalid type passed to js-ref.');
       return this.jsRef(__exprs[0], __exprs[1]);
     }, 2);
@@ -83,14 +81,11 @@ abstract class _$WebLibraryMixin {
       return this.makeTheme();
     }, 0);
     addBuiltin(__env, const SchemeSymbol('theme-set-color!'), (__exprs, __env) {
-      if (__exprs[0] is! Theme ||
-          __exprs[1] is! SchemeSymbol ||
-          __exprs[2] is! Expression)
+      if (__exprs[0] is! Theme || __exprs[1] is! SchemeSymbol)
         throw SchemeException(
             'Argument of invalid type passed to theme-set-color!.');
-      var __value = undefined;
       this.themeSetColor(__exprs[0], __exprs[1], __exprs[2]);
-      return __value;
+      return undefined;
     }, 3);
     addBuiltin(__env, const SchemeSymbol('theme-set-css!'), (__exprs, __env) {
       if (__exprs[0] is! Theme ||
@@ -98,17 +93,15 @@ abstract class _$WebLibraryMixin {
           __exprs[2] is! SchemeString)
         throw SchemeException(
             'Argument of invalid type passed to theme-set-css!.');
-      var __value = undefined;
       this.themeSetCss(__exprs[0], __exprs[1], __exprs[2]);
-      return __value;
+      return undefined;
     }, 3);
     addBuiltin(__env, const SchemeSymbol('apply-theme'), (__exprs, __env) {
       if (__exprs[0] is! Theme)
         throw SchemeException(
             'Argument of invalid type passed to apply-theme.');
-      var __value = undefined;
       this.applyThemeBuiltin(__exprs[0]);
-      return __value;
+      return undefined;
     }, 1);
     addVariableBuiltin(__env, const SchemeSymbol('import'), (__exprs, __env) {
       return AsyncExpression(this.schemeImport(__exprs, __env));

--- a/test/scm_test.dart
+++ b/test/scm_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 import 'package:cs61a_scheme/cs61a_scheme_extra.dart';
 import 'package:cs61a_scheme_impl/impl.dart' show StaffProjectImplementation;
 
-import 'tests.scm' show tests_scm;
+import 'tests.scm' show tests;
 
 main() {
   /// tests.scm all runs in sequence, so we run it as one test here
@@ -22,7 +22,7 @@ String runSchemeTests() {
   print(text) => output += '$text\n';
   int testCount = 0;
   int failedCount = 0;
-  List<String> lines = tests_scm.split("\n");
+  List<String> lines = tests.split("\n");
   String log = "";
   List<String> run = [];
   bool foundError = false;

--- a/test/tests.scm
+++ b/test/tests.scm
@@ -1,7 +1,7 @@
 List list ;/* ; (keeps this readable by both versions of the test runner)
 ;;; The above works because List is both a Scheme built-in and a Dart type
 ;;; (Scheme is case insensitive, so we can capitalize it however we want)
-;;;*/var tests_scm = r""";;;
+;;;*/const tests = r""";;;
 ;;;
 ;;;; Preamble for dart_scheme:
 ;;;; This file consists of the following


### PR DESCRIPTION
The library builder used to be kind of a mess, mixing parsing and code generation and making it hard to maintain.

After this refactor, it's still a bit messier than I'd like, but it's at least split into two phases: we first use the analyzer output to create a `BuiltinStub` and then we convert that to a string of code.

This doesn't add any new features to the builder, but it does slightly change how a few things are generated, eliminating some unnecessary type checks.

Once this is merged, it should be easier to add new features to the library builder. I plan to add support for reading doc comments that could be used in implementing #4.