### PR TITLE
Initial implementation of embedded docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,8 +70,6 @@ of this directory can be imported outside the project.
 - `cs61a_scheme_web.dart` defines the web interpreter library.
 - `builder.dart` defines the code generator, which is used to build helpers for
   libraries of Scheme built-ins.
-- `highlight.dart` defines helpers for highlighting code (using highlight.js)
-- `web_repl.dart` defines the REPL used by the web app
 
 The actual implementation of each of the first three libraries is in
 `lib/src/core`, `lib/src/extra`, and `lib/src/web` respectively. Any files that
@@ -82,8 +80,12 @@ mixins.
 
 Tests are contained in the `test` directory.
 
-The web frontend is contained in the `web` directory (though it depends heavily
-on the libraries).
+Miscellanous documentation (for special forms and other topics) lives in
+`lib/src/core/documentation.md` and is compiled into a form that allows users
+to reference it from the interpreter (`(docs &lt;topic>)`).
+
+The web frontend is contained in the `web` directory and the `lib/web_ui`
+directory.
 
 A simple CLI repl is contained in `tool/repl.dart`. Dart package layout
 conventions would usually include this in `bin`, but since it depends on the
@@ -181,6 +183,18 @@ Note that the Dart `int` type is of limited size when running on the web (64-bit
 floating point), or on all platforms starting in Dart 2 (64-bit integer). The
 conversion from `Integer` to `int` is unspecified for large values.
 
+### Documentation
+
+The code generator will also embed the doc comments on a library into the
+library itself, so they can be referenced from the interpreter. Any built-in
+intended for general use should have a doc comment.
+
+Doc comments must not exceed 80 characters of width, since they will not be
+wrapped when viewed within the interpreter.
+
+You can reference parameter names within your comment by putting the name in
+square brackets. This only works for explicitly named parameters.
+
 ### Importing a `SchemeLibrary`
 
 Only the `StandardLibrary` is included automatically in a new `Interpreter`.
@@ -203,7 +217,7 @@ Before creating a PR, please make sure you have done the following:
 * Run `dartfmt -w .` to format your code (or, even better, configure your editor 
   to do this for you when you save).
 
-* Run `dartanalyzer --fatal-warnings --strong .` to make sure you code doesn't
+* Run `dartanalyzer --fatal-warnings .` to make sure you code doesn't
   cause any analysis errors or warnings. Most editors with Dart support should
   do this automatically.
 

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -200,7 +200,11 @@ class BuiltinStub {
     'SchemeSymbol': 'symbol',
     'Procedure': 'procedure',
     'Pair': 'pair',
-    'SchemeEventListener': 'event listener'
+    'SchemeEventListener': 'event listener',
+    'JsExpression': 'js object',
+    'JsProcedure': 'js function',
+    'Color': 'color',
+    'ImportedLibrary': 'library'
   };
 
   static const Map<String, String> typeChecks = {

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -333,3 +333,31 @@ bool _isVariableArity(MethodDeclaration method) {
   }
   return false;
 }
+
+String generateDocumentation(String markdownSource) {
+  Map<String, String> docs = {};
+  String current;
+  for (var line in markdownSource.split('\n')) {
+    line = line.trim();
+    if (line.startsWith('#')) {
+      current = line.substring(1).trim();
+      if (docs.containsKey(current)) {
+        throw Exception("Duplicate documentation for '$current'");
+      }
+      docs[current] = "";
+    } else {
+      docs[current] += line + '\n';
+    }
+  }
+  var pairs = docs
+      .map((k, v) => MapEntry(
+          json.encode(k) + ": Docs.markdown(" + json.encode(v.trim()) + ")",
+          null))
+      .keys;
+  return """part of cs61a_scheme.core.documentation;
+
+Map<String, Docs> miscDocumentation = {
+  ${pairs.join(',')}
+};
+""";
+}

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -200,6 +200,7 @@ class BuiltinStub {
     'SchemeSymbol': 'symbol',
     'Procedure': 'procedure',
     'Pair': 'pair',
+    'SchemeEventListener': 'event listener'
   };
 
   static const Map<String, String> typeChecks = {

--- a/lib/cs61a_scheme.dart
+++ b/lib/cs61a_scheme.dart
@@ -6,6 +6,7 @@
 /// framework used for diagramming).
 library cs61a_scheme.core;
 
+export 'src/core/documentation.dart';
 export 'src/core/expressions.dart';
 export 'src/core/interpreter.dart';
 export 'src/core/logging.dart';

--- a/lib/src/core/documentation.dart
+++ b/lib/src/core/documentation.dart
@@ -2,21 +2,30 @@ library cs61a_scheme.core.documentation;
 
 import 'widgets.dart';
 
+part 'documentation.g.dart';
+
 class Docs extends Widget {
   final String canonicalName;
   final String comment;
-  final bool isSpecialForm;
   final bool isVariableArity;
   final List<Param> params;
   final String returnType;
+  final bool isMarkdown;
 
-  Docs(this.canonicalName, this.comment, this.params,
-      {this.returnType, this.isSpecialForm = false})
-      : isVariableArity = false;
+  Docs(this.canonicalName, this.comment, this.params, {this.returnType})
+      : isVariableArity = false,
+        isMarkdown = false;
 
-  Docs.variable(this.canonicalName, this.comment,
-      {this.returnType, this.isSpecialForm = false})
+  Docs.variable(this.canonicalName, this.comment, {this.returnType})
       : isVariableArity = true,
+        params = null,
+        isMarkdown = false;
+
+  Docs.markdown(this.comment)
+      : isMarkdown = true,
+        canonicalName = null,
+        isVariableArity = null,
+        returnType = null,
         params = null;
 
   toString() => "Docs for $canonicalName:\n$comment";

--- a/lib/src/core/documentation.dart
+++ b/lib/src/core/documentation.dart
@@ -1,0 +1,29 @@
+library cs61a_scheme.core.documentation;
+
+import 'widgets.dart';
+
+class Docs extends Widget {
+  final String canonicalName;
+  final String comment;
+  final bool isSpecialForm;
+  final bool isVariableArity;
+  final List<Param> params;
+  final String returnType;
+
+  Docs(this.canonicalName, this.comment, this.params,
+      {this.returnType, this.isSpecialForm = false})
+      : isVariableArity = false;
+
+  Docs.variable(this.canonicalName, this.comment,
+      {this.returnType, this.isSpecialForm = false})
+      : isVariableArity = true,
+        params = null;
+
+  toString() => "Docs for $canonicalName:\n$comment";
+}
+
+class Param {
+  final String type;
+  final String name;
+  Param(this.type, this.name);
+}

--- a/lib/src/core/documentation.g.dart
+++ b/lib/src/core/documentation.g.dart
@@ -1,0 +1,36 @@
+part of cs61a_scheme.core.documentation;
+
+Map<String, Docs> miscDocumentation = {
+  "define": Docs.markdown(
+      "**(define symbol expression)**\n\nEvaluates **expression** and binds it to **symbol** in the current environment.\n\n**(define (symbol params...) body...)**\n\nConstructs a lambda with **params** and **body** and binds it to **symbol**."),
+  "if": Docs.markdown(
+      "**(if predicate consequent *alternative*)**\n\nFirst evaluates **predicate**. If true, evaluates and returns **consequent**.\nOtherwise, evaluates and returns ***alternative*** if it exists."),
+  "cond": Docs.markdown(
+      "**(cond *clauses*...)**\nwhere each *clause* is **(test body...)**\n\nEvaluates the **test** of of each clause until one is true, in which case **body**\nis evaluated and returned. **else** may be substituted for the last **test**."),
+  "and": Docs.markdown(
+      "**(and expr...)**\n\nReturns the last **expr** if all are true, or short-circuits and returns it if\none is false."),
+  "or": Docs.markdown(
+      "**(or expr...)**\n\nReturns the last **expr** if all are false, or short-circuits and returns it if\none is true."),
+  "let": Docs.markdown(
+      "**(let (*bindings*) body...)**\nwhere each *binding* is **(symbol expr)**\n\nEvaluates **body** in a new environment with each **symbol** bound to its\ncorresponding expression."),
+  "begin": Docs.markdown(
+      "**(begin exprs...)**\n\nEvaluates each expr in sequence, returning the last one."),
+  "lambda": Docs.markdown(
+      "**(lambda (params...) body...)**\n\nConstructs a lambda procedure with some **body** that takes in **params**.\n\nLambda procedures are lexically scoped, which means they are evaluated in a\nchild of the frame the lambda was defined in."),
+  "mu": Docs.markdown(
+      "**(mu (params...) body...)**\n\nConstructs a mu procedure with some **body** that takes in **params**.\n\nUnlike lambdas, mu procedures are dynamically scoped, which means they are\nevaluated in a child of the frame the mu was called in."),
+  "quote": Docs.markdown(
+      "**(quote expr)**\n\nReturns **expr** without evaluating it.\n\n**'expr** is shorthand for the above."),
+  "delay": Docs.markdown(
+      "**(delay expr)**\n\nConstructs a promise from **expr**, delaying evaluation until forced."),
+  "cons-stream": Docs.markdown(
+      "**(cons-stream car cdr)**\n\nCreates a stream. Equivalent to **(cons car (delay cdr))**."),
+  "define-macro": Docs.markdown(
+      "**(define-macro (symbol params...) body...)**\n\nConstructs a macro and binds it to a symbol. See **(docs macros)** for more details."),
+  "macros": Docs.markdown(
+      "**Macros**\n\nA macro is a procedure that takes in pieces of code and returns a new piece of\ncode that will be evaluated in its place. The evaluation procedure is:\n\n1. Evaluate the operator, which should be a macro.\n2. Apply the macro to the unevaluated operands.\n3. Evaluate the code returned by the macro in the calling environment."),
+  "set!": Docs.markdown(
+      "**(set! symbol expr)**\n\nChanges the value of an existing binding of **symbol** to be the result of\nevaluating **expr**."),
+  "quasiquote": Docs.markdown(
+      "**(quasiquote expr)**\n\nWorks like **quote**, except that **expr** may contain calls to **unquote** that\nwill still be evaluated. **\\`expr** is shorthand for quasiquotation and **,expr** is\nshorthand for unquote.\n\nFor example **\\`(a ,b c)** would be evaluated so that the first and third items are\nthe symbols **a** and **c** but the second item is whatever **b** is bound to.")
+};

--- a/lib/src/core/documentation.md
+++ b/lib/src/core/documentation.md
@@ -1,0 +1,125 @@
+# define
+
+**(define symbol expression)**
+
+Evaluates **expression** and binds it to **symbol** in the current environment.
+
+**(define (symbol params...) body...)**
+
+Constructs a lambda with **params** and **body** and binds it to **symbol**.
+
+# if
+
+**(if predicate consequent *alternative*)**
+
+First evaluates **predicate**. If true, evaluates and returns **consequent**.
+Otherwise, evaluates and returns ***alternative*** if it exists.
+
+# cond
+
+**(cond *clauses*...)**
+where each *clause* is **(test body...)**
+
+Evaluates the **test** of of each clause until one is true, in which case **body**
+is evaluated and returned. **else** may be substituted for the last **test**.
+
+# and
+
+**(and expr...)**
+
+Returns the last **expr** if all are true, or short-circuits and returns it if
+one is false.
+
+# or
+
+**(or expr...)**
+
+Returns the last **expr** if all are false, or short-circuits and returns it if
+one is true.
+
+# let
+
+**(let (*bindings*) body...)**
+where each *binding* is **(symbol expr)**
+
+Evaluates **body** in a new environment with each **symbol** bound to its
+corresponding expression.
+
+# begin
+
+**(begin exprs...)**
+
+Evaluates each expr in sequence, returning the last one.
+
+# lambda
+
+**(lambda (params...) body...)**
+
+Constructs a lambda procedure with some **body** that takes in **params**.
+
+Lambda procedures are lexically scoped, which means they are evaluated in a
+child of the frame the lambda was defined in.
+
+# mu
+
+**(mu (params...) body...)**
+
+Constructs a mu procedure with some **body** that takes in **params**.
+
+Unlike lambdas, mu procedures are dynamically scoped, which means they are
+evaluated in a child of the frame the mu was called in.
+
+# quote
+
+**(quote expr)**
+
+Returns **expr** without evaluating it.
+
+**'expr** is shorthand for the above.
+
+# delay
+
+**(delay expr)**
+
+Constructs a promise from **expr**, delaying evaluation until forced.
+
+# cons-stream
+
+**(cons-stream car cdr)**
+
+Creates a stream. Equivalent to **(cons car (delay cdr))**.
+
+# define-macro
+
+**(define-macro (symbol params...) body...)**
+
+Constructs a macro and binds it to a symbol. See **(docs macros)** for more details.
+
+# macros
+
+**Macros**
+
+A macro is a procedure that takes in pieces of code and returns a new piece of
+code that will be evaluated in its place. The evaluation procedure is:
+
+1. Evaluate the operator, which should be a macro.
+2. Apply the macro to the unevaluated operands.
+3. Evaluate the code returned by the macro in the calling environment.
+
+# set!
+
+**(set! symbol expr)**
+
+Changes the value of an existing binding of **symbol** to be the result of
+evaluating **expr**.
+
+# quasiquote
+
+**(quasiquote expr)**
+
+Works like **quote**, except that **expr** may contain calls to **unquote** that
+will still be evaluated. **\`expr** is shorthand for quasiquotation and **,expr** is
+shorthand for unquote.
+
+For example **\`(a ,b c)** would be evaluated so that the first and third items are
+the symbols **a** and **c** but the second item is whatever **b** is bound to.

--- a/lib/src/core/procedures.dart
+++ b/lib/src/core/procedures.dart
@@ -1,5 +1,6 @@
 library cs61a_scheme.core.procedures;
 
+import 'documentation.dart';
 import 'expressions.dart';
 import 'logging.dart';
 import 'widgets.dart';
@@ -13,6 +14,9 @@ abstract class Procedure extends SelfEvaluating {
 
   /// Intrinsic name of this procedure. `null` if none.
   SchemeSymbol get name;
+
+  /// Documentation associated with this procedure. `null` if none.
+  Docs docs;
 
   /// Calls the procedure in [env] with a list of unevaluated [operands].
   Expression call(PairOrEmpty operands, Frame env) =>

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -2,6 +2,7 @@ library cs61a_scheme.core.standard_library;
 
 import 'dart:math' show pow;
 
+import 'documentation.dart';
 import 'expressions.dart';
 import 'logging.dart';
 import 'numbers.dart';
@@ -16,24 +17,30 @@ part 'standard_library.g.dart';
 /// the built-ins and performs type checking on arguments).
 @schemelib
 class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
+  /// Applies [procedure] to the given [args]
   Expression apply(Procedure procedure, PairOrEmpty args, Frame env) =>
       schemeApply(procedure, args, env);
 
+  /// Displays [message] without a line break at the end
   void display(Expression message, Frame env) {
     env.interpreter.logger(DisplayOutput(message), false);
   }
 
+  /// Raises an error with the given [message].
   Expression error(Expression message) {
     throw SchemeException(message.toString(), true, message);
   }
 
+  /// Raises an error with the given [message] and no traceback.
   @SchemeSymbol('error-notrace')
   Expression errorNoTrace(Expression message) {
     throw SchemeException(message.toString(), false, message);
   }
 
+  /// Evaluates [expr] in the current environment
   Expression eval(Expression expr, Frame env) => schemeEval(expr, env);
 
+  /// Exits the interpreter (behavior may vary)
   Expression exit() {
     throw const ExitException();
   }
@@ -42,72 +49,97 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
     throw UnimplementedError("load has not yet been implemented");
   }
 
+  /// Displays a line break
   void newline(Frame env) {
     env.interpreter.logger(const TextMessage(""), true);
   }
 
+  /// Logs [message] to the interpreter.
   void print(Expression message, Frame env) {
     env.interpreter.logger(message, true);
   }
 
+  /// Returns true if [val] is an atomic expression.
   @SchemeSymbol("atom?")
   bool isAtom(Expression val) =>
       val is Boolean || val is Number || val is SchemeSymbol || val.isNil;
 
+  /// Returns true if [val] is an integer.
   @SchemeSymbol("integer?")
   bool isInteger(Expression val) => val is Integer;
 
+  /// Returns true if [val] is a well-formed list.
   @SchemeSymbol("list?")
   bool isList(Expression val) => val is PairOrEmpty && val.wellFormed;
 
+  /// Returns true if [val] is an number.
   @SchemeSymbol("number?")
   bool isNumber(Expression val) => val is Number;
 
+  /// Returns true if [val] is the empty list.
   @SchemeSymbol("null?")
   bool isNull(Expression val) => val.isNil;
 
+  /// Returns true if [val] is a pair.
   @SchemeSymbol("pair?")
   bool isPair(Expression val) => val is Pair;
 
+  /// Returns true if [val] is a procedure.
   @SchemeSymbol("procedure?")
   bool isProcedure(Expression val) => val is Procedure;
 
+  /// Returns true if [val] is a promise.
   @SchemeSymbol("promise?")
   bool isPromise(Expression val) => val is Promise;
 
+  /// Returns true if [val] is a string.
   @SchemeSymbol("string?")
   bool isString(Expression val) => val is SchemeString;
 
+  /// Returns true if [val] is a symbol.
   @SchemeSymbol("symbol?")
   bool isSymbol(Expression val) => val is SchemeSymbol;
 
+  /// Appends zero or more lists together into a single list.
   Expression append(List<Expression> args) => Pair.append(args);
 
+  /// Gets the first item in [val].
   Expression car(Pair val) => val.first;
 
+  /// Gets the second item in [val] (typically the rest of a well-formed list).
   Expression cdr(Pair val) => val.second;
 
+  /// Constructs a pair from values [car] and [cdr].
   Pair cons(Expression car, Expression cdr) => Pair(car, cdr);
 
+  /// Finds the length of a well-formed Scheme list.
   num length(PairOrEmpty lst) => lst.lengthOrCycle;
 
+  /// Constructs a list from zero or more arguments.
   PairOrEmpty list(List<Expression> args) => PairOrEmpty.fromIterable(args);
 
+  /// Constructs a new list from calling [fn] on each item in [lst].
   PairOrEmpty map(Procedure fn, PairOrEmpty lst, Frame env) =>
       PairOrEmpty.fromIterable(
           lst.map((item) => completeEval(fn.apply(Pair(item, nil), env))));
 
+  /// Constructs a new list of all items in [lst] that return true when passed
+  /// to [pred].
   PairOrEmpty filter(Procedure pred, PairOrEmpty lst, Frame env) =>
       PairOrEmpty.fromIterable(lst.where(
           (item) => completeEval(pred.apply(Pair(item, nil), env)).isTruthy));
 
+  /// Reduces [lst] into a single expression by combining items with [combiner].
   Expression reduce(Procedure combiner, PairOrEmpty lst, Frame env) =>
       lst.reduce((a, b) => combiner.apply(list([a, b]), env));
 
+  /// Adds 0 or more numbers together.
   @SchemeSymbol("+")
   Number add(List<Expression> args) =>
       allNumbers(args).fold(Number.zero, (a, b) => a + b);
 
+  /// If called with one number, negates it.
+  /// Otherwise, subtracts the sum of all remaining arguments from the first.
   @SchemeSymbol("-")
   @MinArgs(1)
   Number sub(List<Expression> args) {
@@ -116,10 +148,13 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
     return numbers.skip(1).fold(numbers.first, (a, b) => a - b);
   }
 
+  /// Multiples 0 or more numbers together.
   @SchemeSymbol("*")
   Number mul(List<Expression> args) =>
       allNumbers(args).fold(Number.one, (a, b) => a * b);
 
+  /// If called with one number, finds its reciprocal.
+  /// Otherwise, divides the first argument by the product of the rest.
   @SchemeSymbol("/")
   @MinArgs(1)
   Number truediv(List<Expression> args) {
@@ -128,8 +163,10 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
     return numbers.skip(1).fold(numbers.first, (a, b) => a / b);
   }
 
+  /// Finds the absolute value of [arg].
   Number abs(Number arg) => arg < Number.zero ? -arg : arg;
 
+  /// Raises [base] to [power].
   Number expt(Number base, Number power) {
     if (power is Integer) {
       Number total = Number.one;
@@ -141,10 +178,13 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
     return Number.fromNum(pow(base.toJS(), power.toJS()));
   }
 
+  /// Finds a % b.
   Number modulo(Number a, Number b) => a % b;
 
+  /// Divides [a] by [b] using truncating division.
   Number quotient(Number a, Number b) => a ~/ b;
 
+  /// Finds the remainder when dividing [a] by [b].
   Number remainder(Number a, Number b) {
     Number mod = modulo(a, b);
     while (mod > Number.zero && a < Number.zero) {
@@ -153,6 +193,10 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
     return mod;
   }
 
+  /// Determines if [x] and [y] are the same object.
+  ///
+  /// For the purposes of this procedure, equivalent numbers, symbols, and
+  /// strings are considered the same object.
   @SchemeSymbol("eq?")
   bool isEq(Expression x, Expression y) {
     if (x is Number && y is Number) return x == y;
@@ -161,51 +205,67 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
     return identical(x, y);
   }
 
+  /// Determines if [x] and [y] hold equivalent values.
   @SchemeSymbol("equal?")
   bool isEqual(Expression x, Expression y) => x == y;
 
+  /// Negates the truthiness of [arg].
   @SchemeSymbol("not")
   bool not(Expression arg) => !arg.isTruthy;
 
+  /// Compares [x] and [y] for equality.
   @SchemeSymbol("=")
   bool eqNumbers(Number x, Number y) => x == y;
 
+  /// Returns true if [x] is less than [y].
   @SchemeSymbol("<")
   bool lt(Number x, Number y) => x < y;
 
+  /// Returns true if [x] is greater than [y].
   @SchemeSymbol(">")
   bool gt(Number x, Number y) => x > y;
 
+  /// Returns true if [x] is less than or equal to [y].
   @SchemeSymbol("<=")
   bool le(Number x, Number y) => x <= y;
 
+  /// Returns true if [x] is greater than or equal to [y].
   @SchemeSymbol(">=")
   bool ge(Number x, Number y) => x >= y;
 
+  /// Returns true if [x] is even.
   @SchemeSymbol("even?")
   bool isEven(Number x) => x % Number.two == Number.zero;
 
+  /// Returns true if [x] is odd.
   @SchemeSymbol("odd?")
   bool isOdd(Number x) => x % Number.two == Number.one;
 
+  /// Returns true if [x] is zero.
   @SchemeSymbol("zero?")
   bool isZero(Number x) => x == Number.zero;
 
-  Expression force(Promise p) => p.force();
+  /// Forces [promise], evaluating it if necessary.
+  Expression force(Promise promise) => promise.force();
 
+  /// Finds the rest of [stream].
+  ///
+  /// Equivalent to (force (cdr [stream]))
   @SchemeSymbol("cdr-stream")
-  Expression cdrStream(Pair p) => force(cdr(p));
+  Expression cdrStream(Pair stream) => force(cdr(stream));
 
+  /// Mutates the car of [pair] to be [val].
   @SchemeSymbol("set-car!")
   @TriggerEventAfter(const SchemeSymbol("pair-mutation"))
-  void setCar(Pair p, Expression val) {
-    p.first = val;
+  void setCar(Pair pair, Expression val) {
+    pair.first = val;
   }
 
+  /// Mutates the cdr of [pair] to be [val].
   @SchemeSymbol("set-cdr!")
   @TriggerEventAfter(const SchemeSymbol("pair-mutation"))
-  void setCdr(Pair p, Expression val) {
-    p.second = val;
+  void setCdr(Pair pair, Expression val) {
+    pair.second = val;
   }
 
   @SchemeSymbol("call/cc")

--- a/lib/src/core/standard_library.g.dart
+++ b/lib/src/core/standard_library.g.dart
@@ -53,10 +53,10 @@ abstract class _$StandardLibraryMixin {
   bool isEven(Number x);
   bool isOdd(Number x);
   bool isZero(Number x);
-  Expression force(Promise p);
-  Expression cdrStream(Pair p);
-  void setCar(Pair p, Expression val);
-  void setCdr(Pair p, Expression val);
+  Expression force(Promise promise);
+  Expression cdrStream(Pair stream);
+  void setCar(Pair pair, Expression val);
+  void setCdr(Pair pair, Expression val);
   Expression callWithCurrentContinuation(Procedure procedure, Frame env);
   String getRuntimeType(Expression expression);
   void importAll(Frame __env) {
@@ -64,199 +64,353 @@ abstract class _$StandardLibraryMixin {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to apply.');
       return this.apply(__exprs[0], __exprs[1], __env);
-    }, 2);
+    }, 2,
+        docs: Docs("apply", "Applies [procedure] to the given [args]\n",
+            [Param("procedure", "procedure"), Param(null, "args")]));
     addBuiltin(__env, const SchemeSymbol("display"), (__exprs, __env) {
       this.display(__exprs[0], __env);
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "display",
+            "Displays [message] without a line break at the end\n",
+            [Param(null, "message")]));
     addBuiltin(__env, const SchemeSymbol("error"), (__exprs, __env) {
       return this.error(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs("error", "Raises an error with the given [message].\n",
+            [Param(null, "message")]));
     addBuiltin(__env, const SchemeSymbol('error-notrace'), (__exprs, __env) {
       return this.errorNoTrace(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs(
+            'error-notrace',
+            "Raises an error with the given [message] and no traceback.\n",
+            [Param(null, "message")]));
     addBuiltin(__env, const SchemeSymbol("eval"), (__exprs, __env) {
       return this.eval(__exprs[0], __env);
-    }, 1);
+    }, 1,
+        docs: Docs("eval", "Evaluates [expr] in the current environment\n",
+            [Param(null, "expr")]));
     addBuiltin(__env, const SchemeSymbol("exit"), (__exprs, __env) {
       return this.exit();
-    }, 0);
+    }, 0,
+        docs: Docs("exit", "Exits the interpreter (behavior may vary)\n", []));
     addBuiltin(__env, const SchemeSymbol("load"), (__exprs, __env) {
       return this.load(__exprs[0], __env);
     }, 1);
     addBuiltin(__env, const SchemeSymbol("newline"), (__exprs, __env) {
       this.newline(__env);
       return undefined;
-    }, 0);
+    }, 0, docs: Docs("newline", "Displays a line break\n", []));
     addBuiltin(__env, const SchemeSymbol("print"), (__exprs, __env) {
       this.print(__exprs[0], __env);
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs("print", "Logs [message] to the interpreter.\n",
+            [Param(null, "message")]));
     addBuiltin(__env, const SchemeSymbol("atom?"), (__exprs, __env) {
       return Boolean(this.isAtom(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("atom?", "Returns true if [val] is an atomic expression.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("integer?"), (__exprs, __env) {
       return Boolean(this.isInteger(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("integer?", "Returns true if [val] is an integer.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("list?"), (__exprs, __env) {
       return Boolean(this.isList(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("list?", "Returns true if [val] is a well-formed list.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("number?"), (__exprs, __env) {
       return Boolean(this.isNumber(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("number?", "Returns true if [val] is an number.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("null?"), (__exprs, __env) {
       return Boolean(this.isNull(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("null?", "Returns true if [val] is the empty list.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("pair?"), (__exprs, __env) {
       return Boolean(this.isPair(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "pair?", "Returns true if [val] is a pair.\n", [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("procedure?"), (__exprs, __env) {
       return Boolean(this.isProcedure(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("procedure?", "Returns true if [val] is a procedure.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("promise?"), (__exprs, __env) {
       return Boolean(this.isPromise(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("promise?", "Returns true if [val] is a promise.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("string?"), (__exprs, __env) {
       return Boolean(this.isString(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("string?", "Returns true if [val] is a string.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("symbol?"), (__exprs, __env) {
       return Boolean(this.isSymbol(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("symbol?", "Returns true if [val] is a symbol.\n",
+            [Param(null, "val")],
+            returnType: "bool"));
     addVariableBuiltin(__env, const SchemeSymbol("append"), (__exprs, __env) {
       return this.append(__exprs);
-    }, 0, -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable("append",
+            "Appends zero or more lists together into a single list.\n"));
     addBuiltin(__env, const SchemeSymbol("car"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to car.');
       return this.car(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "car", "Gets the first item in [val].\n", [Param("pair", "val")]));
     addBuiltin(__env, const SchemeSymbol("cdr"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to cdr.');
       return this.cdr(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "cdr",
+            "Gets the second item in [val] (typically the rest of a well-formed list).\n",
+            [Param("pair", "val")]));
     addBuiltin(__env, const SchemeSymbol("cons"), (__exprs, __env) {
       return this.cons(__exprs[0], __exprs[1]);
-    }, 2);
+    }, 2,
+        docs: Docs("cons", "Constructs a pair from values [car] and [cdr].\n",
+            [Param(null, "car"), Param(null, "cdr")],
+            returnType: "pair"));
     addBuiltin(__env, const SchemeSymbol("length"), (__exprs, __env) {
       if (__exprs[0] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to length.');
       return Number.fromNum(this.length(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("length", "Finds the length of a well-formed Scheme list.\n",
+            [Param(null, "lst")],
+            returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("list"), (__exprs, __env) {
       return this.list(__exprs);
-    }, 0, -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable(
+            "list", "Constructs a list from zero or more arguments.\n"));
     addBuiltin(__env, const SchemeSymbol("map"), (__exprs, __env) {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to map.');
       return this.map(__exprs[0], __exprs[1], __env);
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "map",
+            "Constructs a new list from calling [fn] on each item in [lst].\n",
+            [Param("procedure", "fn"), Param(null, "lst")]));
     addBuiltin(__env, const SchemeSymbol("filter"), (__exprs, __env) {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to filter.');
       return this.filter(__exprs[0], __exprs[1], __env);
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "filter",
+            "Constructs a new list of all items in [lst] that return true when passed\nto [pred].\n",
+            [Param("procedure", "pred"), Param(null, "lst")]));
     addBuiltin(__env, const SchemeSymbol("reduce"), (__exprs, __env) {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to reduce.');
       return this.reduce(__exprs[0], __exprs[1], __env);
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "reduce",
+            "Reduces [lst] into a single expression by combining items with [combiner].\n",
+            [Param("procedure", "combiner"), Param(null, "lst")]));
     addVariableBuiltin(__env, const SchemeSymbol("+"), (__exprs, __env) {
       return this.add(__exprs);
-    }, 0, -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable("+", "Adds 0 or more numbers together.\n",
+            returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("-"), (__exprs, __env) {
       return this.sub(__exprs);
-    }, 1, -1);
+    }, 1,
+        maxArgs: -1,
+        docs: Docs.variable("-",
+            "If called with one number, negates it.\nOtherwise, subtracts the sum of all remaining arguments from the first.\n",
+            returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("*"), (__exprs, __env) {
       return this.mul(__exprs);
-    }, 0, -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable("*", "Multiples 0 or more numbers together.\n",
+            returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("/"), (__exprs, __env) {
       return this.truediv(__exprs);
-    }, 1, -1);
+    }, 1,
+        maxArgs: -1,
+        docs: Docs.variable("/",
+            "If called with one number, finds its reciprocal.\nOtherwise, divides the first argument by the product of the rest.\n",
+            returnType: "num"));
     addBuiltin(__env, const SchemeSymbol("abs"), (__exprs, __env) {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to abs.');
       return this.abs(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs("abs", "Finds the absolute value of [arg].\n",
+            [Param("num", "arg")],
+            returnType: "num"));
     addBuiltin(__env, const SchemeSymbol("expt"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to expt.');
       return this.expt(__exprs[0], __exprs[1]);
-    }, 2);
+    }, 2,
+        docs: Docs("expt", "Raises [base] to [power].\n",
+            [Param("num", "base"), Param("num", "power")],
+            returnType: "num"));
     addBuiltin(__env, const SchemeSymbol("modulo"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to modulo.');
       return this.modulo(__exprs[0], __exprs[1]);
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "modulo", "Finds a % b.\n", [Param("num", "a"), Param("num", "b")],
+            returnType: "num"));
     addBuiltin(__env, const SchemeSymbol("quotient"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to quotient.');
       return this.quotient(__exprs[0], __exprs[1]);
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "quotient",
+            "Divides [a] by [b] using truncating division.\n",
+            [Param("num", "a"), Param("num", "b")],
+            returnType: "num"));
     addBuiltin(__env, const SchemeSymbol("remainder"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to remainder.');
       return this.remainder(__exprs[0], __exprs[1]);
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "remainder",
+            "Finds the remainder when dividing [a] by [b].\n",
+            [Param("num", "a"), Param("num", "b")],
+            returnType: "num"));
     addBuiltin(__env, const SchemeSymbol("eq?"), (__exprs, __env) {
       return Boolean(this.isEq(__exprs[0], __exprs[1]));
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "eq?",
+            "Determines if [x] and [y] are the same object.\n\nFor the purposes of this procedure, equivalent numbers, symbols, and\nstrings are considered the same object.\n",
+            [Param(null, "x"), Param(null, "y")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("equal?"), (__exprs, __env) {
       return Boolean(this.isEqual(__exprs[0], __exprs[1]));
-    }, 2);
+    }, 2,
+        docs: Docs(
+            "equal?",
+            "Determines if [x] and [y] hold equivalent values.\n",
+            [Param(null, "x"), Param(null, "y")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("not"), (__exprs, __env) {
       return Boolean(this.not(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "not", "Negates the truthiness of [arg].\n", [Param(null, "arg")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("="), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to =.');
       return Boolean(this.eqNumbers(__exprs[0], __exprs[1]));
-    }, 2);
+    }, 2,
+        docs: Docs("=", "Compares [x] and [y] for equality.\n",
+            [Param("num", "x"), Param("num", "y")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("<"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to <.');
       return Boolean(this.lt(__exprs[0], __exprs[1]));
-    }, 2);
+    }, 2,
+        docs: Docs("<", "Returns true if [x] is less than [y].\n",
+            [Param("num", "x"), Param("num", "y")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol(">"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to >.');
       return Boolean(this.gt(__exprs[0], __exprs[1]));
-    }, 2);
+    }, 2,
+        docs: Docs(">", "Returns true if [x] is greater than [y].\n",
+            [Param("num", "x"), Param("num", "y")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("<="), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to <=.');
       return Boolean(this.le(__exprs[0], __exprs[1]));
-    }, 2);
+    }, 2,
+        docs: Docs("<=", "Returns true if [x] is less than or equal to [y].\n",
+            [Param("num", "x"), Param("num", "y")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol(">="), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to >=.');
       return Boolean(this.ge(__exprs[0], __exprs[1]));
-    }, 2);
+    }, 2,
+        docs: Docs(
+            ">=",
+            "Returns true if [x] is greater than or equal to [y].\n",
+            [Param("num", "x"), Param("num", "y")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("even?"), (__exprs, __env) {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to even?.');
       return Boolean(this.isEven(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "even?", "Returns true if [x] is even.\n", [Param("num", "x")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("odd?"), (__exprs, __env) {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to odd?.');
       return Boolean(this.isOdd(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("odd?", "Returns true if [x] is odd.\n", [Param("num", "x")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("zero?"), (__exprs, __env) {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to zero?.');
       return Boolean(this.isZero(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "zero?", "Returns true if [x] is zero.\n", [Param("num", "x")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("force"), (__exprs, __env) {
       if (__exprs[0] is! Promise)
         throw SchemeException('Argument of invalid type passed to force.');
       return this.force(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs("force", "Forces [promise], evaluating it if necessary.\n",
+            [Param(null, "promise")]));
     addBuiltin(__env, const SchemeSymbol("cdr-stream"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to cdr-stream.');
       return this.cdrStream(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "cdr-stream",
+            "Finds the rest of [stream].\n\nEquivalent to (force (cdr [stream]))\n",
+            [Param("pair", "stream")]));
     addBuiltin(__env, const SchemeSymbol("set-car!"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to set-car!.');
@@ -264,7 +418,9 @@ abstract class _$StandardLibraryMixin {
       __env.interpreter.triggerEvent(
           const SchemeSymbol("pair-mutation"), [undefined], __env);
       return undefined;
-    }, 2);
+    }, 2,
+        docs: Docs("set-car!", "Mutates the car of [pair] to be [val].\n",
+            [Param("pair", "pair"), Param(null, "val")]));
     addBuiltin(__env, const SchemeSymbol("set-cdr!"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to set-cdr!.');
@@ -272,7 +428,9 @@ abstract class _$StandardLibraryMixin {
       __env.interpreter.triggerEvent(
           const SchemeSymbol("pair-mutation"), [undefined], __env);
       return undefined;
-    }, 2);
+    }, 2,
+        docs: Docs("set-cdr!", "Mutates the cdr of [pair] to be [val].\n",
+            [Param("pair", "pair"), Param(null, "val")]));
     addBuiltin(__env, const SchemeSymbol("call/cc"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)
         throw SchemeException('Argument of invalid type passed to call/cc.');

--- a/lib/src/core/utils.dart
+++ b/lib/src/core/utils.dart
@@ -2,6 +2,7 @@ library cs61a_scheme.core.utils;
 
 import 'dart:async';
 
+import 'documentation.dart';
 import 'expressions.dart';
 import 'logging.dart';
 import 'procedures.dart';
@@ -70,13 +71,15 @@ Expression evalCallExpression(Pair expr, Frame env) {
 
 Expression completeEval(val) => val is Thunk ? val.evaluate(null) : val;
 
-addBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int args) {
-  env.define(name, BuiltinProcedure.fixed(name, fn, args), true);
+addBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int args,
+    {Docs docs}) {
+  env.define(name, BuiltinProcedure.fixed(name, fn, args)..docs = docs, true);
 }
 
 addVariableBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int minArgs,
-    [int maxArgs = -1]) {
+    {int maxArgs = -1, Docs docs}) {
   var p = BuiltinProcedure.variable(name, fn, minArgs, maxArgs);
+  p.docs = docs;
   env.define(name, p, true);
 }
 

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -135,12 +135,29 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
     env.interpreter.importLibrary(LogicLibrary());
   }
 
-  /// Returns the documentation for [procedure], if it exists.
-  Docs docs(Procedure procedure) {
-    if (procedure.docs == null) {
-      throw SchemeException(
-          "No documentation for ${procedure.name} exists", false);
+  /// Returns the documentation for [topic], if it exists.
+  @noeval
+  Docs docs(SchemeSymbol topic, Frame env) {
+    if (miscDocumentation.containsKey(topic.toString())) {
+      return miscDocumentation[topic.toString()];
+    } else if (env.interpreter.globalEnv.bindings.containsKey(topic)) {
+      var value = env.interpreter.globalEnv.bindings[topic];
+      if (value is Procedure && value.docs != null) {
+        return value.docs;
+      }
     }
-    return procedure.docs;
+    throw SchemeException('No documentation for "$topic" available.');
+  }
+
+  /// Logs all documentation available to the interpreter.
+  @SchemeSymbol('all-docs')
+  void allDocs(Frame env) {
+    for (var docs in miscDocumentation.values) {
+      env.interpreter.logger(docs, true);
+    }
+    var all = env.interpreter.globalEnv.bindings.values.whereType<Procedure>();
+    for (var proc in all.toSet().where((proc) => proc.docs != null)) {
+      env.interpreter.logger(proc.docs, true);
+    }
   }
 }

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -123,4 +123,12 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   void logicStart(Frame env) {
     env.interpreter.importLibrary(LogicLibrary());
   }
+
+  Expression docs(Procedure proc) {
+    if (proc.docs == null) {
+      return undefined;
+      throw SchemeException("No documentation for ${proc.name} exists", false);
+    }
+    return proc.docs;
+  }
 }

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -56,17 +56,22 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   Boolean isCompleted(AsyncExpression expr) =>
       expr.complete ? schemeTrue : schemeFalse;
 
+  /// Creates a diagram of [expression].
   Diagram draw(Expression expression) => Diagram(expression);
 
+  /// Create a diagram of the current environment.
   Diagram diagram(Frame env) => Diagram(env);
 
+  /// Visualizes the execution of a piece of code.
   @noeval
   Visualization visualize(List<Expression> code, Frame env) =>
       Visualization(code, env);
 
+  /// Returns a list of all bindings in the current environment.
   PairOrEmpty bindings(Frame env) =>
       PairOrEmpty.fromIterable(env.bindings.keys);
 
+  /// Triggers an event with a given name (first arg) and arguments.
   @SchemeSymbol('trigger-event')
   @MinArgs(1)
   void triggerEvent(List<Expression> exprs, Frame env) {
@@ -76,6 +81,7 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
     env.interpreter.triggerEvent(exprs[0], exprs.skip(1).toList(), env);
   }
 
+  /// Sets up an listener to call [onEvent] when an event with [id] occurs.
   @SchemeSymbol('listen-for')
   SchemeEventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env) {
     var callback = (exprs, env) {
@@ -95,16 +101,19 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
     return SchemeEventListener(id, callback);
   }
 
+  /// Cancels [listener] from triggering on new events.
   @SchemeSymbol('cancel-listener')
   void cancelListener(SchemeEventListener listener, Frame env) {
     env.interpreter.stopListening(listener.id, listener.callback);
   }
 
+  /// Cancels all listeners for event [id].
   @SchemeSymbol('cancel-all')
   void cancelAll(SchemeSymbol id, Frame env) {
     env.interpreter.stopAllListeners(id);
   }
 
+  /// Constructs a string from the display values of any number of expressions.
   @SchemeSymbol('string-append')
   String stringAppend(List<Expression> exprs) =>
       exprs.map((e) => e.display).join('');
@@ -114,21 +123,24 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   Expression deserialize(String json) =>
       Serialization.deserializeFromJson(json);
 
+  /// Renders all provided text as a block of Markdown.
   MarkdownWidget formatted(List<Expression> expressions, Frame env) {
     String text = expressions.map((expr) => expr.display).join('');
     return MarkdownWidget(text, inline: true, env: env);
   }
 
+  /// Loads procedures to run Logic code within the interpreter.
   @SchemeSymbol('logic')
   void logicStart(Frame env) {
     env.interpreter.importLibrary(LogicLibrary());
   }
 
-  Expression docs(Procedure proc) {
-    if (proc.docs == null) {
-      return undefined;
-      throw SchemeException("No documentation for ${proc.name} exists", false);
+  /// Returns the documentation for [procedure], if it exists.
+  Docs docs(Procedure procedure) {
+    if (procedure.docs == null) {
+      throw SchemeException(
+          "No documentation for ${procedure.name} exists", false);
     }
-    return proc.docs;
+    return procedure.docs;
   }
 }

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -21,6 +21,7 @@ abstract class _$ExtraLibraryMixin {
   Expression deserialize(String json);
   MarkdownWidget formatted(List<Expression> expressions, Frame env);
   void logicStart(Frame env);
+  Expression docs(Procedure proc);
   void importAll(Frame __env) {
     addBuiltin(__env, const SchemeSymbol("run-async"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)
@@ -44,7 +45,8 @@ abstract class _$ExtraLibraryMixin {
       return this.diagram(__env);
     }, 0);
     addVariableOperandBuiltin(
-        __env, const SchemeSymbol("visualize"), this.visualize, 0, -1);
+        __env, const SchemeSymbol("visualize"), this.visualize, 0,
+        maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol("bindings"), (__exprs, __env) {
       return this.bindings(__env);
     }, 0);
@@ -52,7 +54,7 @@ abstract class _$ExtraLibraryMixin {
         (__exprs, __env) {
       this.triggerEvent(__exprs, __env);
       return undefined;
-    }, 1, -1);
+    }, 1, maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol('listen-for'), (__exprs, __env) {
       if (__exprs[0] is! SchemeSymbol || __exprs[1] is! Procedure)
         throw SchemeException('Argument of invalid type passed to listen-for.');
@@ -74,7 +76,7 @@ abstract class _$ExtraLibraryMixin {
     addVariableBuiltin(__env, const SchemeSymbol('string-append'),
         (__exprs, __env) {
       return SchemeString(this.stringAppend(__exprs));
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol("serialize"), (__exprs, __env) {
       if (__exprs[0] is! Serializable)
         throw SchemeException('Argument of invalid type passed to serialize.');
@@ -87,10 +89,16 @@ abstract class _$ExtraLibraryMixin {
       return this.deserialize((__exprs[0] as SchemeString).value);
     }, 1);
     addVariableBuiltin(
-        __env, const SchemeSymbol("formatted"), this.formatted, 0, -1);
+        __env, const SchemeSymbol("formatted"), this.formatted, 0,
+        maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol('logic'), (__exprs, __env) {
       this.logicStart(__env);
       return undefined;
     }, 0);
+    addBuiltin(__env, const SchemeSymbol("docs"), (__exprs, __env) {
+      if (__exprs[0] is! Procedure)
+        throw SchemeException('Argument of invalid type passed to docs.');
+      return this.docs(__exprs[0]);
+    }, 1);
   }
 }

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -21,7 +21,8 @@ abstract class _$ExtraLibraryMixin {
   Expression deserialize(String json);
   MarkdownWidget formatted(List<Expression> expressions, Frame env);
   void logicStart(Frame env);
-  Expression docs(Procedure proc);
+  Docs docs(SchemeSymbol topic, Frame env);
+  void allDocs(Frame env);
   void importAll(Frame __env) {
     addBuiltin(__env, const SchemeSymbol("run-async"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)
@@ -40,43 +41,71 @@ abstract class _$ExtraLibraryMixin {
     }, 1);
     addBuiltin(__env, const SchemeSymbol("draw"), (__exprs, __env) {
       return this.draw(__exprs[0]);
-    }, 1);
+    }, 1,
+        docs: Docs("draw", "Creates a diagram of [expression].\n",
+            [Param(null, "expression")]));
     addBuiltin(__env, const SchemeSymbol("diagram"), (__exprs, __env) {
       return this.diagram(__env);
-    }, 0);
+    }, 0,
+        docs: Docs(
+            "diagram", "Create a diagram of the current environment.\n", []));
     addVariableOperandBuiltin(
         __env, const SchemeSymbol("visualize"), this.visualize, 0,
-        maxArgs: -1);
+        maxArgs: -1,
+        docs: Docs.variable(
+            "visualize", "Visualizes the execution of a piece of code.\n"));
     addBuiltin(__env, const SchemeSymbol("bindings"), (__exprs, __env) {
       return this.bindings(__env);
-    }, 0);
+    }, 0,
+        docs: Docs(
+            "bindings",
+            "Returns a list of all bindings in the current environment.\n",
+            []));
     addVariableBuiltin(__env, const SchemeSymbol('trigger-event'),
         (__exprs, __env) {
       this.triggerEvent(__exprs, __env);
       return undefined;
-    }, 1, maxArgs: -1);
+    }, 1,
+        maxArgs: -1,
+        docs: Docs.variable('trigger-event',
+            "Triggers an event with a given name (first arg) and arguments.\n"));
     addBuiltin(__env, const SchemeSymbol('listen-for'), (__exprs, __env) {
       if (__exprs[0] is! SchemeSymbol || __exprs[1] is! Procedure)
         throw SchemeException('Argument of invalid type passed to listen-for.');
       return this.listenFor(__exprs[0], __exprs[1], __env);
-    }, 2);
+    }, 2,
+        docs: Docs(
+            'listen-for',
+            "Sets up an listener to call [onEvent] when an event with [id] occurs.\n",
+            [Param("symbol", "id"), Param("procedure", "onEvent")],
+            returnType: "event listener"));
     addBuiltin(__env, const SchemeSymbol('cancel-listener'), (__exprs, __env) {
       if (__exprs[0] is! SchemeEventListener)
         throw SchemeException(
             'Argument of invalid type passed to cancel-listener.');
       this.cancelListener(__exprs[0], __env);
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs(
+            'cancel-listener',
+            "Cancels [listener] from triggering on new events.\n",
+            [Param("event listener", "listener")]));
     addBuiltin(__env, const SchemeSymbol('cancel-all'), (__exprs, __env) {
       if (__exprs[0] is! SchemeSymbol)
         throw SchemeException('Argument of invalid type passed to cancel-all.');
       this.cancelAll(__exprs[0], __env);
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs('cancel-all', "Cancels all listeners for event [id].\n",
+            [Param("symbol", "id")]));
     addVariableBuiltin(__env, const SchemeSymbol('string-append'),
         (__exprs, __env) {
       return SchemeString(this.stringAppend(__exprs));
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable('string-append',
+            "Constructs a string from the display values of any number of expressions.\n",
+            returnType: "string"));
     addBuiltin(__env, const SchemeSymbol("serialize"), (__exprs, __env) {
       if (__exprs[0] is! Serializable)
         throw SchemeException('Argument of invalid type passed to serialize.');
@@ -90,15 +119,31 @@ abstract class _$ExtraLibraryMixin {
     }, 1);
     addVariableBuiltin(
         __env, const SchemeSymbol("formatted"), this.formatted, 0,
-        maxArgs: -1);
+        maxArgs: -1,
+        docs: Docs.variable("formatted",
+            "Renders all provided text as a block of Markdown.\n"));
     addBuiltin(__env, const SchemeSymbol('logic'), (__exprs, __env) {
       this.logicStart(__env);
       return undefined;
-    }, 0);
-    addBuiltin(__env, const SchemeSymbol("docs"), (__exprs, __env) {
-      if (__exprs[0] is! Procedure)
+    }, 0,
+        docs: Docs(
+            'logic',
+            "Loads procedures to run Logic code within the interpreter.\n",
+            []));
+    addOperandBuiltin(__env, const SchemeSymbol("docs"), (__exprs, __env) {
+      if (__exprs[0] is! SchemeSymbol)
         throw SchemeException('Argument of invalid type passed to docs.');
-      return this.docs(__exprs[0]);
-    }, 1);
+      return this.docs(__exprs[0], __env);
+    }, 1,
+        docs: Docs(
+            "docs",
+            "Returns the documentation for [topic], if it exists.\n",
+            [Param("symbol", "topic")]));
+    addBuiltin(__env, const SchemeSymbol('all-docs'), (__exprs, __env) {
+      this.allDocs(__env);
+      return undefined;
+    }, 0,
+        docs: Docs('all-docs',
+            "Logs all documentation available to the interpreter.\n", []));
   }
 }

--- a/lib/src/extra/logic_library.dart
+++ b/lib/src/extra/logic_library.dart
@@ -15,6 +15,7 @@ part 'logic_library.g.dart';
 class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
   List<logic.Fact> facts = [];
 
+  /// Declares the first relation to be true iff all other relations are true.
   @SchemeSymbol('fact')
   @SchemeSymbol('!')
   @noeval
@@ -22,6 +23,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
     facts.add(logic.Fact(exprs.first, exprs.skip(1)));
   }
 
+  /// Queries all sets of variable assignments that make all relations true.
   @SchemeSymbol('query')
   @SchemeSymbol('?')
   @noeval
@@ -36,6 +38,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
     return null;
   }
 
+  /// Finds the first set of variable assignments that makes all relations true.
   @SchemeSymbol('query-one')
   @noeval
   void queryOne(List<Expression> exprs, Frame env) {
@@ -49,6 +52,7 @@ class LogicLibrary extends SchemeLibrary with _$LogicLibraryMixin {
     return null;
   }
 
+  /// Compiles all declared facts in the current environment into Prolog.
   @SchemeSymbol('prolog')
   String prolog() => facts.map((f) => f.toProlog()).join('\n') + '\n';
 }

--- a/lib/src/extra/logic_library.g.dart
+++ b/lib/src/extra/logic_library.g.dart
@@ -14,7 +14,7 @@ abstract class _$LogicLibraryMixin {
         (__exprs, __env) {
       this.fact(__exprs);
       return undefined;
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     __env.bindings[const SchemeSymbol('!')] =
         __env.bindings[const SchemeSymbol('fact')];
     __env.hidden[const SchemeSymbol('!')] = true;
@@ -22,7 +22,7 @@ abstract class _$LogicLibraryMixin {
         (__exprs, __env) {
       this.query(__exprs, __env);
       return undefined;
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     __env.bindings[const SchemeSymbol('?')] =
         __env.bindings[const SchemeSymbol('query')];
     __env.hidden[const SchemeSymbol('?')] = true;
@@ -30,7 +30,7 @@ abstract class _$LogicLibraryMixin {
         (__exprs, __env) {
       this.queryOne(__exprs, __env);
       return undefined;
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol('prolog'), (__exprs, __env) {
       return SchemeString(this.prolog());
     }, 0);

--- a/lib/src/extra/logic_library.g.dart
+++ b/lib/src/extra/logic_library.g.dart
@@ -14,7 +14,10 @@ abstract class _$LogicLibraryMixin {
         (__exprs, __env) {
       this.fact(__exprs);
       return undefined;
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable('fact',
+            "Declares the first relation to be true iff all other relations are true.\n"));
     __env.bindings[const SchemeSymbol('!')] =
         __env.bindings[const SchemeSymbol('fact')];
     __env.hidden[const SchemeSymbol('!')] = true;
@@ -22,7 +25,10 @@ abstract class _$LogicLibraryMixin {
         (__exprs, __env) {
       this.query(__exprs, __env);
       return undefined;
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable('query',
+            "Queries all sets of variable assignments that make all relations true.\n"));
     __env.bindings[const SchemeSymbol('?')] =
         __env.bindings[const SchemeSymbol('query')];
     __env.hidden[const SchemeSymbol('?')] = true;
@@ -30,9 +36,17 @@ abstract class _$LogicLibraryMixin {
         (__exprs, __env) {
       this.queryOne(__exprs, __env);
       return undefined;
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable('query-one',
+            "Finds the first set of variable assignments that makes all relations true.\n"));
     addBuiltin(__env, const SchemeSymbol('prolog'), (__exprs, __env) {
       return SchemeString(this.prolog());
-    }, 0);
+    }, 0,
+        docs: Docs(
+            'prolog',
+            "Compiles all declared facts in the current environment into Prolog.\n",
+            [],
+            returnType: "string"));
   }
 }

--- a/lib/src/extra/operand_procedures.dart
+++ b/lib/src/extra/operand_procedures.dart
@@ -14,13 +14,16 @@ class OperandBuiltinProcedure extends BuiltinProcedure {
   Expression call(PairOrEmpty operands, Frame env) => apply(operands, env);
 }
 
-addOperandBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int args) {
-  env.define(name, OperandBuiltinProcedure.fixed(name, fn, args), true);
+addOperandBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int args,
+    {Docs docs}) {
+  env.define(
+      name, OperandBuiltinProcedure.fixed(name, fn, args)..docs = docs, true);
 }
 
 addVariableOperandBuiltin(
     Frame env, SchemeSymbol name, SchemeBuiltin fn, int minArgs,
-    [int maxArgs = -1]) {
+    {int maxArgs = -1, Docs docs}) {
   var p = OperandBuiltinProcedure.variable(name, fn, minArgs, maxArgs);
+  p.docs = docs;
   env.define(name, p, true);
 }

--- a/lib/src/web/renderer.dart
+++ b/lib/src/web/renderer.dart
@@ -280,7 +280,16 @@ class _Renderer {
   }
 
   Element convertDocs(Docs docs, bool spaced) {
-    var frame = PreElement()..classes = ['docs'];
+    var frame = DivElement()..classes = ['docs'];
+    if (docs.isMarkdown) {
+      String html = md.markdownToHtml(docs.comment,
+          extensionSet: md.ExtensionSet.gitHubFlavored, inlineOnly: true);
+      return Element.span()
+        ..classes = ['md-docs']
+        ..appendHtml(html,
+            validator: NodeValidatorBuilder.common()
+              ..allowNavigation(_AnyUriPolicy()));
+    }
     var comment = "<span class='comment'>${docs.comment}</span>";
     var table = TableElement()..classes = ['usage'];
     var names = TableRowElement();

--- a/lib/src/web/turtle_library.dart
+++ b/lib/src/web/turtle_library.dart
@@ -19,27 +19,34 @@ class TurtleLibrary extends SchemeLibrary with _$TurtleLibraryMixin {
     turtle = Turtle(element, interpreter);
   }
 
+  /// Moves the turtle forward by [distance] units.
   @turtlestart
   @SchemeSymbol('forward')
   @SchemeSymbol('fd')
   void forward(num distance) => turtle.forward(distance);
 
+  /// Moves the turtle backward by [distance] units.
   @turtlestart
   @SchemeSymbol('backward')
   @SchemeSymbol('back')
   @SchemeSymbol('bk')
   void backward(num distance) => turtle.forward(-distance);
 
+  /// Rotates the turtle counter-clockwise by [angle] degrees.
   @turtlestart
   @SchemeSymbol('left')
   @SchemeSymbol('lt')
   void left(num angle) => turtle.rotate(-angle);
 
+  /// Rotates the turtle clockwise by [angle] degrees.
   @turtlestart
   @SchemeSymbol('right')
   @SchemeSymbol('rt')
   void right(num angle) => turtle.rotate(angle);
 
+  /// Moves the turtle in a circle of some radius (first arg).
+  ///
+  /// An optional second argument sets the length of the arc in degrees.
   @turtlestart
   @MinArgs(1)
   @MaxArgs(2)
@@ -57,41 +64,49 @@ class TurtleLibrary extends SchemeLibrary with _$TurtleLibraryMixin {
     turtle.circle(exprs[0].toJS(), exprs[1].toJS());
   }
 
+  /// Moves the turtle to position ([x], [y]) in Cartesian coordinates.
   @turtlestart
   @SchemeSymbol('setposition')
   @SchemeSymbol('setpos')
   @SchemeSymbol('goto')
   void setPosition(num x, num y) => turtle.goto(x, y);
 
+  /// Sets the turtle's heading to be [heading] degrees.
   @turtlestart
   @SchemeSymbol('setheading')
   @SchemeSymbol('seth')
   void setHeading(num heading) => turtle.heading = heading;
 
+  /// Raises the pen from the canvas.
   @turtlestart
   @SchemeSymbol('penup')
   @SchemeSymbol('pu')
   void penUp() => turtle.penDown = false;
 
+  /// Lowers the pen onto the canvas.
   @turtlestart
   @SchemeSymbol('pendown')
   @SchemeSymbol('pd')
   void penDown() => turtle.penDown = true;
 
+  /// Clears the current turtle state.
   @turtlestart
   @SchemeSymbol('turtle-clear')
   void turtleClear() => turtle.clear();
 
+  /// Sets the pen color of the turtle.
   @turtlestart
   void color(Expression color) {
     turtle.penColor = Color.fromAnything(color);
   }
 
+  /// Begins outlining a region to be filled in.
   @turtlestart
   @SchemeSymbol('begin_fill')
   @SchemeSymbol('begin-fill')
   void beginFill() => turtle.beginFill();
 
+  /// Fills in the region outlined since begin_fill in the current pen color.
   @turtlestart
   @SchemeSymbol('end_fill')
   @SchemeSymbol('end-fill')
@@ -102,20 +117,25 @@ class TurtleLibrary extends SchemeLibrary with _$TurtleLibraryMixin {
     env.interpreter.logger(TextMessage(msg), true);
   }
 
+  /// Closes the turtle canvas, reseting its state.
   @SchemeSymbol('turtle-exit')
   void exit() => turtle.reset();
 
+  /// Sets the background color of the turtle canvas.
   @turtlestart
   void bgcolor(Expression color) {
     turtle.backgroundColor = Color.fromAnything(color);
   }
 
+  /// Sets the [size] of the turtle's pen.
   @turtlestart
   void pensize(num size) {
     turtle.penSize = size;
   }
 
-  void help(Frame env) {
+  /// Displays information on how to adjust and close the turtle canvas.
+  @SchemeSymbol('turtle-help')
+  void turtleHelp(Frame env) {
     var cw = turtle.element.style.width;
     var ch = turtle.element.style.height;
     var gw = turtle.gridWidth;
@@ -128,6 +148,9 @@ class TurtleLibrary extends SchemeLibrary with _$TurtleLibraryMixin {
         true);
   }
 
+  /// Sets the internal dimensions of the grid the turtle moves/draws on.
+  ///
+  /// This will clear the current state of the turtle.
   @SchemeSymbol('turtle-grid')
   void setGridSize(int width, int height) {
     turtle.gridWidth = width;
@@ -135,29 +158,37 @@ class TurtleLibrary extends SchemeLibrary with _$TurtleLibraryMixin {
     turtle.clear();
   }
 
+  /// Sets the exterior dimensions of the turtle's canvas.
+  ///
+  /// This does not effect the current state of the turtle.
   @SchemeSymbol('turtle-canvas')
   void setCanvasSize(int width, int height) {
     turtle.elementWidth = width;
     turtle.elementHeight = height;
   }
 
+  /// Draws a box with [color] in the turtle's current pixel size at ([x], [y])
   @turtlestart
   void pixel(num x, num y, Expression color) {
     turtle.drawPixel(x, y, Color.fromAnything(color));
   }
 
+  /// Sets the current pixel size of the turtle
   void pixelsize(int size) {
     turtle.pixelSize = size;
   }
 
+  /// Returns the number of "pixels" in the width of the turtle's grid.
   @SchemeSymbol('screen_width')
   @SchemeSymbol('screen-width')
   num screenWidth() => turtle.gridWidth / turtle.pixelSize;
 
+  /// Returns the number of "pixels" in the height of the turtle's grid.
   @SchemeSymbol('screen_height')
   @SchemeSymbol('screen-height')
   num screenHeight() => turtle.gridHeight / turtle.pixelSize;
 
+  /// This turtle procedure is not supported in the web interpreter.
   @SchemeSymbol('unsupported')
   @SchemeSymbol('speed')
   @SchemeSymbol('showturtle')

--- a/lib/src/web/turtle_library.g.dart
+++ b/lib/src/web/turtle_library.g.dart
@@ -22,7 +22,7 @@ abstract class _$TurtleLibraryMixin {
   void exit();
   void bgcolor(Expression color);
   void pensize(num size);
-  void help(Frame env);
+  void turtleHelp(Frame env);
   void setGridSize(int width, int height);
   void setCanvasSize(int width, int height);
   void pixel(num x, num y, Expression color);
@@ -38,7 +38,9 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.forward(__exprs[0].toJS());
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs('forward', "Moves the turtle forward by [distance] units.\n",
+            [Param("num", "distance")]));
     __env.bindings[const SchemeSymbol('fd')] =
         __env.bindings[const SchemeSymbol('forward')];
     __env.hidden[const SchemeSymbol('fd')] = true;
@@ -48,7 +50,11 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.backward(__exprs[0].toJS());
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs(
+            'backward',
+            "Moves the turtle backward by [distance] units.\n",
+            [Param("num", "distance")]));
     __env.bindings[const SchemeSymbol('back')] =
         __env.bindings[const SchemeSymbol('backward')];
     __env.hidden[const SchemeSymbol('back')] = true;
@@ -61,7 +67,11 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.left(__exprs[0].toJS());
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs(
+            'left',
+            "Rotates the turtle counter-clockwise by [angle] degrees.\n",
+            [Param("num", "angle")]));
     __env.bindings[const SchemeSymbol('lt')] =
         __env.bindings[const SchemeSymbol('left')];
     __env.hidden[const SchemeSymbol('lt')] = true;
@@ -71,7 +81,11 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.right(__exprs[0].toJS());
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs(
+            'right',
+            "Rotates the turtle clockwise by [angle] degrees.\n",
+            [Param("num", "angle")]));
     __env.bindings[const SchemeSymbol('rt')] =
         __env.bindings[const SchemeSymbol('right')];
     __env.hidden[const SchemeSymbol('rt')] = true;
@@ -79,7 +93,10 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.circle(__exprs);
       return undefined;
-    }, 1, maxArgs: 2);
+    }, 1,
+        maxArgs: 2,
+        docs: Docs.variable("circle",
+            "Moves the turtle in a circle of some radius (first arg).\n\nAn optional second argument sets the length of the arc in degrees.\n"));
     addBuiltin(__env, const SchemeSymbol('setposition'), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException(
@@ -87,7 +104,11 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.setPosition(__exprs[0].toJS(), __exprs[1].toJS());
       return undefined;
-    }, 2);
+    }, 2,
+        docs: Docs(
+            'setposition',
+            "Moves the turtle to position ([x], [y]) in Cartesian coordinates.\n",
+            [Param("num", "x"), Param("num", "y")]));
     __env.bindings[const SchemeSymbol('setpos')] =
         __env.bindings[const SchemeSymbol('setposition')];
     __env.hidden[const SchemeSymbol('setpos')] = true;
@@ -100,7 +121,11 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.setHeading(__exprs[0].toJS());
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs(
+            'setheading',
+            "Sets the turtle's heading to be [heading] degrees.\n",
+            [Param("num", "heading")]));
     __env.bindings[const SchemeSymbol('seth')] =
         __env.bindings[const SchemeSymbol('setheading')];
     __env.hidden[const SchemeSymbol('seth')] = true;
@@ -108,7 +133,7 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.penUp();
       return undefined;
-    }, 0);
+    }, 0, docs: Docs('penup', "Raises the pen from the canvas.\n", []));
     __env.bindings[const SchemeSymbol('pu')] =
         __env.bindings[const SchemeSymbol('penup')];
     __env.hidden[const SchemeSymbol('pu')] = true;
@@ -116,7 +141,7 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.penDown();
       return undefined;
-    }, 0);
+    }, 0, docs: Docs('pendown', "Lowers the pen onto the canvas.\n", []));
     __env.bindings[const SchemeSymbol('pd')] =
         __env.bindings[const SchemeSymbol('pendown')];
     __env.hidden[const SchemeSymbol('pd')] = true;
@@ -124,17 +149,21 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.turtleClear();
       return undefined;
-    }, 0);
+    }, 0, docs: Docs('turtle-clear', "Clears the current turtle state.\n", []));
     addBuiltin(__env, const SchemeSymbol("color"), (__exprs, __env) {
       turtle.show();
       this.color(__exprs[0]);
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs("color", "Sets the pen color of the turtle.\n",
+            [Param(null, "color")]));
     addBuiltin(__env, const SchemeSymbol('begin_fill'), (__exprs, __env) {
       turtle.show();
       this.beginFill();
       return undefined;
-    }, 0);
+    }, 0,
+        docs: Docs(
+            'begin_fill', "Begins outlining a region to be filled in.\n", []));
     __env.bindings[const SchemeSymbol('begin-fill')] =
         __env.bindings[const SchemeSymbol('begin_fill')];
     __env.hidden[const SchemeSymbol('begin-fill')] = true;
@@ -142,7 +171,11 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.endFill();
       return undefined;
-    }, 0);
+    }, 0,
+        docs: Docs(
+            'end_fill',
+            "Fills in the region outlined since begin_fill in the current pen color.\n",
+            []));
     __env.bindings[const SchemeSymbol('end-fill')] =
         __env.bindings[const SchemeSymbol('end_fill')];
     __env.hidden[const SchemeSymbol('end-fill')] = true;
@@ -153,59 +186,95 @@ abstract class _$TurtleLibraryMixin {
     addBuiltin(__env, const SchemeSymbol('turtle-exit'), (__exprs, __env) {
       this.exit();
       return undefined;
-    }, 0);
+    }, 0,
+        docs: Docs('turtle-exit',
+            "Closes the turtle canvas, reseting its state.\n", []));
     addBuiltin(__env, const SchemeSymbol("bgcolor"), (__exprs, __env) {
       turtle.show();
       this.bgcolor(__exprs[0]);
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "bgcolor",
+            "Sets the background color of the turtle canvas.\n",
+            [Param(null, "color")]));
     addBuiltin(__env, const SchemeSymbol("pensize"), (__exprs, __env) {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to pensize.');
       turtle.show();
       this.pensize(__exprs[0].toJS());
       return undefined;
-    }, 1);
-    addBuiltin(__env, const SchemeSymbol("help"), (__exprs, __env) {
-      this.help(__env);
+    }, 1,
+        docs: Docs("pensize", "Sets the [size] of the turtle's pen.\n",
+            [Param("num", "size")]));
+    addBuiltin(__env, const SchemeSymbol('turtle-help'), (__exprs, __env) {
+      this.turtleHelp(__env);
       return undefined;
-    }, 0);
+    }, 0,
+        docs: Docs(
+            'turtle-help',
+            "Displays information on how to adjust and close the turtle canvas.\n",
+            []));
     addBuiltin(__env, const SchemeSymbol('turtle-grid'), (__exprs, __env) {
       if (__exprs[0] is! Integer || __exprs[1] is! Integer)
         throw SchemeException(
             'Argument of invalid type passed to turtle-grid.');
       this.setGridSize(__exprs[0].toJS().toInt(), __exprs[1].toJS().toInt());
       return undefined;
-    }, 2);
+    }, 2,
+        docs: Docs(
+            'turtle-grid',
+            "Sets the internal dimensions of the grid the turtle moves/draws on.\n\nThis will clear the current state of the turtle.\n",
+            [Param("int", "width"), Param("int", "height")]));
     addBuiltin(__env, const SchemeSymbol('turtle-canvas'), (__exprs, __env) {
       if (__exprs[0] is! Integer || __exprs[1] is! Integer)
         throw SchemeException(
             'Argument of invalid type passed to turtle-canvas.');
       this.setCanvasSize(__exprs[0].toJS().toInt(), __exprs[1].toJS().toInt());
       return undefined;
-    }, 2);
+    }, 2,
+        docs: Docs(
+            'turtle-canvas',
+            "Sets the exterior dimensions of the turtle's canvas.\n\nThis does not effect the current state of the turtle.\n",
+            [Param("int", "width"), Param("int", "height")]));
     addBuiltin(__env, const SchemeSymbol("pixel"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException('Argument of invalid type passed to pixel.');
       turtle.show();
       this.pixel(__exprs[0].toJS(), __exprs[1].toJS(), __exprs[2]);
       return undefined;
-    }, 3);
+    }, 3,
+        docs: Docs(
+            "pixel",
+            "Draws a box with [color] in the turtle's current pixel size at ([x], [y])\n",
+            [Param("num", "x"), Param("num", "y"), Param(null, "color")]));
     addBuiltin(__env, const SchemeSymbol("pixelsize"), (__exprs, __env) {
       if (__exprs[0] is! Integer)
         throw SchemeException('Argument of invalid type passed to pixelsize.');
       this.pixelsize(__exprs[0].toJS().toInt());
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs("pixelsize", "Sets the current pixel size of the turtle\n",
+            [Param("int", "size")]));
     addBuiltin(__env, const SchemeSymbol('screen_width'), (__exprs, __env) {
       return Number.fromNum(this.screenWidth());
-    }, 0);
+    }, 0,
+        docs: Docs(
+            'screen_width',
+            "Returns the number of \"pixels\" in the width of the turtle's grid.\n",
+            [],
+            returnType: "num"));
     __env.bindings[const SchemeSymbol('screen-width')] =
         __env.bindings[const SchemeSymbol('screen_width')];
     __env.hidden[const SchemeSymbol('screen-width')] = true;
     addBuiltin(__env, const SchemeSymbol('screen_height'), (__exprs, __env) {
       return Number.fromNum(this.screenHeight());
-    }, 0);
+    }, 0,
+        docs: Docs(
+            'screen_height',
+            "Returns the number of \"pixels\" in the height of the turtle's grid.\n",
+            [],
+            returnType: "num"));
     __env.bindings[const SchemeSymbol('screen-height')] =
         __env.bindings[const SchemeSymbol('screen_height')];
     __env.hidden[const SchemeSymbol('screen-height')] = true;
@@ -213,7 +282,10 @@ abstract class _$TurtleLibraryMixin {
         (__exprs, __env) {
       this.unsupported(__exprs, __env);
       return undefined;
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable('unsupported',
+            "This turtle procedure is not supported in the web interpreter.\n"));
     __env.bindings[const SchemeSymbol('speed')] =
         __env.bindings[const SchemeSymbol('unsupported')];
     __env.hidden[const SchemeSymbol('speed')] = true;

--- a/lib/src/web/turtle_library.g.dart
+++ b/lib/src/web/turtle_library.g.dart
@@ -79,7 +79,7 @@ abstract class _$TurtleLibraryMixin {
       turtle.show();
       this.circle(__exprs);
       return undefined;
-    }, 1, 2);
+    }, 1, maxArgs: 2);
     addBuiltin(__env, const SchemeSymbol('setposition'), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
         throw SchemeException(
@@ -213,7 +213,7 @@ abstract class _$TurtleLibraryMixin {
         (__exprs, __env) {
       this.unsupported(__exprs, __env);
       return undefined;
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     __env.bindings[const SchemeSymbol('speed')] =
         __env.bindings[const SchemeSymbol('unsupported')];
     __env.hidden[const SchemeSymbol('speed')] = true;

--- a/lib/src/web/web_library.dart
+++ b/lib/src/web/web_library.dart
@@ -38,14 +38,21 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     Procedure.jsProcedure = (procedure) => SchemeFunction(procedure, env);
   }
 
+  /// Evaluates a piece of JavaScript code and returns the result.
+  ///
+  /// Compatible types will automatically be converted between the languages.
   Expression js(List<Expression> exprs) {
     String code = exprs.map((e) => e.display).join("");
     return jsEval(code);
   }
 
+  /// Returns the global JavaScript context.
+  ///
+  /// In a browser, this is the window object.
   @SchemeSymbol("js-context")
-  Expression jsContext() => JsExpression(context);
+  JsExpression jsContext() => JsExpression(context);
 
+  /// Sets [property] of [obj] to be [value].
   @SchemeSymbol("js-set!")
   Expression jsSet(JsExpression obj, Expression property, Expression value) {
     if (property is! SchemeSymbol && property is! SchemeString) {
@@ -55,6 +62,7 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     return obj;
   }
 
+  /// Returns [property] of [obj].
   @SchemeSymbol("js-ref")
   Expression jsRef(JsExpression obj, Expression property) {
     if (property is! SchemeSymbol && property is! SchemeString) {
@@ -63,6 +71,7 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     return jsToScheme(obj.obj[property.display]);
   }
 
+  /// Calls a method (second arg) on a JS object (first arg) with some args.
   @SchemeSymbol("js-call")
   @MinArgs(2)
   Expression jsCall(List<Expression> expressions) {
@@ -77,6 +86,7 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     return jsToScheme(jsObj.callMethod(method.toString(), args));
   }
 
+  /// Constructs a new JS object of a type (first arg) with some arguments.
   @SchemeSymbol("js-object")
   Expression jsObject(List<Expression> expressions) {
     if (expressions[0] is! SchemeSymbol && expressions[0] is! SchemeString) {
@@ -86,34 +96,46 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     return jsToScheme(JsObject(context[expressions.first.display], args));
   }
 
+  /// Returns true if [expression] is a JS object.
   @SchemeSymbol("js-object?")
   bool isJsObject(Expression expression) => expression is JsExpression;
 
+  /// Returns true if [expression] is a JS function.
   @SchemeSymbol("js-procedure?")
   bool isJsProcedure(Expression expression) => expression is JsProcedure;
 
+  /// Constructs a color from values [r], [g], and [b].
   Color rgb(int r, int g, int b) => Color(r, g, b);
 
+  /// Constructs a color from values [r], [g], [b], and [a].
   Color rgba(int r, int g, int b, num a) => Color(r, g, b, a.toDouble());
 
+  /// Constructs a color from [hex].
   Color hex(String hex) => Color.fromHexString(hex);
 
+  /// Creates a new theme.
   @SchemeSymbol("make-theme")
   Theme makeTheme() => Theme();
 
+  /// For [theme], sets the color for [property] to be [color].
   @SchemeSymbol('theme-set-color!')
   void themeSetColor(Theme theme, SchemeSymbol property, Expression color) {
     theme.colors[property] = Color.fromAnything(color);
   }
 
+  /// For [theme], sets the extra CSS for [property] to be [code].
   @SchemeSymbol('theme-set-css!')
   void themeSetCss(Theme theme, SchemeSymbol property, SchemeString code) {
     theme.cssProps[property] = code;
   }
 
+  /// Applies [theme] to the current interface.
   @SchemeSymbol('apply-theme')
   void applyThemeBuiltin(Theme theme) => applyTheme(theme, css, styleElement);
 
+  /// Imports a library (first arg) as a module (returned asynchronously)
+  ///
+  /// Remaining args should be symbols in the library to be bound directly.
   @SchemeSymbol('import')
   Future<Expression> schemeImport(List<Expression> args, Frame env) async {
     if (args[0] is! SchemeSymbol && args[0] is! SchemeString) {
@@ -131,6 +153,7 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     return import(id, symbols, env);
   }
 
+  /// Imports a library at [id] directly into the current environment.
   @SchemeSymbol('import-inline')
   Future<Expression> schemeImportInline(Expression id, Frame env) async {
     if (id is! SchemeSymbol && id is! SchemeString) {
@@ -140,10 +163,12 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     return undefined;
   }
 
+  /// References an [id] bound within [imported].
   @SchemeSymbol('lib-ref')
   Expression libraryReference(ImportedLibrary imported, SchemeSymbol id) =>
       imported.reference(id);
 
+  /// Loads and applies a [theme].
   Future<Expression> theme(SchemeSymbol theme, Frame env) async {
     ImportedLibrary lib = await import('scm/theme/$theme', [], env);
     Expression myTheme = lib.reference(const SchemeSymbol('imported-theme'));
@@ -152,6 +177,7 @@ class WebLibrary extends SchemeLibrary with _$WebLibraryMixin {
     return undefined;
   }
 
+  /// Converts [color] to a string of CSS.
   @SchemeSymbol("color->css")
   String colorToCss(Color color) => color.toCSS();
 }

--- a/lib/src/web/web_library.g.dart
+++ b/lib/src/web/web_library.g.dart
@@ -6,7 +6,7 @@ part of cs61a_scheme.web.web_library;
 // ignore_for_file: unnecessary_lambdas
 abstract class _$WebLibraryMixin {
   Expression js(List<Expression> exprs);
-  Expression jsContext();
+  JsExpression jsContext();
   Expression jsSet(JsExpression obj, Expression property, Expression value);
   Expression jsRef(JsExpression obj, Expression property);
   Expression jsCall(List<Expression> expressions);
@@ -28,33 +28,64 @@ abstract class _$WebLibraryMixin {
   void importAll(Frame __env) {
     addVariableBuiltin(__env, const SchemeSymbol("js"), (__exprs, __env) {
       return this.js(__exprs);
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable("js",
+            "Evaluates a piece of JavaScript code and returns the result.\n\nCompatible types will automatically be converted between the languages.\n"));
     addBuiltin(__env, const SchemeSymbol("js-context"), (__exprs, __env) {
       return this.jsContext();
-    }, 0);
+    }, 0,
+        docs: Docs(
+            "js-context",
+            "Returns the global JavaScript context.\n\nIn a browser, this is the window object.\n",
+            [],
+            returnType: "js object"));
     addBuiltin(__env, const SchemeSymbol("js-set!"), (__exprs, __env) {
       if (__exprs[0] is! JsExpression)
         throw SchemeException('Argument of invalid type passed to js-set!.');
       return this.jsSet(__exprs[0], __exprs[1], __exprs[2]);
-    }, 3);
+    }, 3,
+        docs: Docs("js-set!", "Sets [property] of [obj] to be [value].\n", [
+          Param("js object", "obj"),
+          Param(null, "property"),
+          Param(null, "value")
+        ]));
     addBuiltin(__env, const SchemeSymbol("js-ref"), (__exprs, __env) {
       if (__exprs[0] is! JsExpression)
         throw SchemeException('Argument of invalid type passed to js-ref.');
       return this.jsRef(__exprs[0], __exprs[1]);
-    }, 2);
+    }, 2,
+        docs: Docs("js-ref", "Returns [property] of [obj].\n",
+            [Param("js object", "obj"), Param(null, "property")]));
     addVariableBuiltin(__env, const SchemeSymbol("js-call"), (__exprs, __env) {
       return this.jsCall(__exprs);
-    }, 2, maxArgs: -1);
+    }, 2,
+        maxArgs: -1,
+        docs: Docs.variable("js-call",
+            "Calls a method (second arg) on a JS object (first arg) with some args.\n"));
     addVariableBuiltin(__env, const SchemeSymbol("js-object"),
         (__exprs, __env) {
       return this.jsObject(__exprs);
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable("js-object",
+            "Constructs a new JS object of a type (first arg) with some arguments.\n"));
     addBuiltin(__env, const SchemeSymbol("js-object?"), (__exprs, __env) {
       return Boolean(this.isJsObject(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "js-object?",
+            "Returns true if [expression] is a JS object.\n",
+            [Param(null, "expression")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("js-procedure?"), (__exprs, __env) {
       return Boolean(this.isJsProcedure(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "js-procedure?",
+            "Returns true if [expression] is a JS function.\n",
+            [Param(null, "expression")],
+            returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("rgb"), (__exprs, __env) {
       if (__exprs[0] is! Integer ||
           __exprs[1] is! Integer ||
@@ -62,7 +93,10 @@ abstract class _$WebLibraryMixin {
         throw SchemeException('Argument of invalid type passed to rgb.');
       return this.rgb(__exprs[0].toJS().toInt(), __exprs[1].toJS().toInt(),
           __exprs[2].toJS().toInt());
-    }, 3);
+    }, 3,
+        docs: Docs("rgb", "Constructs a color from values [r], [g], and [b].\n",
+            [Param("int", "r"), Param("int", "g"), Param("int", "b")],
+            returnType: "color"));
     addBuiltin(__env, const SchemeSymbol("rgba"), (__exprs, __env) {
       if (__exprs[0] is! Integer ||
           __exprs[1] is! Integer ||
@@ -71,22 +105,41 @@ abstract class _$WebLibraryMixin {
         throw SchemeException('Argument of invalid type passed to rgba.');
       return this.rgba(__exprs[0].toJS().toInt(), __exprs[1].toJS().toInt(),
           __exprs[2].toJS().toInt(), __exprs[3].toJS());
-    }, 4);
+    }, 4,
+        docs: Docs(
+            "rgba",
+            "Constructs a color from values [r], [g], [b], and [a].\n",
+            [
+              Param("int", "r"),
+              Param("int", "g"),
+              Param("int", "b"),
+              Param("num", "a")
+            ],
+            returnType: "color"));
     addBuiltin(__env, const SchemeSymbol("hex"), (__exprs, __env) {
       if (__exprs[0] is! SchemeString)
         throw SchemeException('Argument of invalid type passed to hex.');
       return this.hex((__exprs[0] as SchemeString).value);
-    }, 1);
+    }, 1,
+        docs: Docs(
+            "hex", "Constructs a color from [hex].\n", [Param("string", "hex")],
+            returnType: "color"));
     addBuiltin(__env, const SchemeSymbol("make-theme"), (__exprs, __env) {
       return this.makeTheme();
-    }, 0);
+    }, 0, docs: Docs("make-theme", "Creates a new theme.\n", []));
     addBuiltin(__env, const SchemeSymbol('theme-set-color!'), (__exprs, __env) {
       if (__exprs[0] is! Theme || __exprs[1] is! SchemeSymbol)
         throw SchemeException(
             'Argument of invalid type passed to theme-set-color!.');
       this.themeSetColor(__exprs[0], __exprs[1], __exprs[2]);
       return undefined;
-    }, 3);
+    }, 3,
+        docs: Docs('theme-set-color!',
+            "For [theme], sets the color for [property] to be [color].\n", [
+          Param(null, "theme"),
+          Param("symbol", "property"),
+          Param(null, "color")
+        ]));
     addBuiltin(__env, const SchemeSymbol('theme-set-css!'), (__exprs, __env) {
       if (__exprs[0] is! Theme ||
           __exprs[1] is! SchemeSymbol ||
@@ -95,34 +148,56 @@ abstract class _$WebLibraryMixin {
             'Argument of invalid type passed to theme-set-css!.');
       this.themeSetCss(__exprs[0], __exprs[1], __exprs[2]);
       return undefined;
-    }, 3);
+    }, 3,
+        docs: Docs('theme-set-css!',
+            "For [theme], sets the extra CSS for [property] to be [code].\n", [
+          Param(null, "theme"),
+          Param("symbol", "property"),
+          Param("string", "code")
+        ]));
     addBuiltin(__env, const SchemeSymbol('apply-theme'), (__exprs, __env) {
       if (__exprs[0] is! Theme)
         throw SchemeException(
             'Argument of invalid type passed to apply-theme.');
       this.applyThemeBuiltin(__exprs[0]);
       return undefined;
-    }, 1);
+    }, 1,
+        docs: Docs('apply-theme', "Applies [theme] to the current interface.\n",
+            [Param(null, "theme")]));
     addVariableBuiltin(__env, const SchemeSymbol('import'), (__exprs, __env) {
       return AsyncExpression(this.schemeImport(__exprs, __env));
-    }, 0, maxArgs: -1);
+    }, 0,
+        maxArgs: -1,
+        docs: Docs.variable('import',
+            "Imports a library (first arg) as a module (returned asynchronously)\n\nRemaining args should be symbols in the library to be bound directly.\n"));
     addBuiltin(__env, const SchemeSymbol('import-inline'), (__exprs, __env) {
       return AsyncExpression(this.schemeImportInline(__exprs[0], __env));
-    }, 1);
+    }, 1,
+        docs: Docs(
+            'import-inline',
+            "Imports a library at [id] directly into the current environment.\n",
+            [Param(null, "id")]));
     addBuiltin(__env, const SchemeSymbol('lib-ref'), (__exprs, __env) {
       if (__exprs[0] is! ImportedLibrary || __exprs[1] is! SchemeSymbol)
         throw SchemeException('Argument of invalid type passed to lib-ref.');
       return this.libraryReference(__exprs[0], __exprs[1]);
-    }, 2);
+    }, 2,
+        docs: Docs('lib-ref', "References an [id] bound within [imported].\n",
+            [Param("library", "imported"), Param("symbol", "id")]));
     addBuiltin(__env, const SchemeSymbol("theme"), (__exprs, __env) {
       if (__exprs[0] is! SchemeSymbol)
         throw SchemeException('Argument of invalid type passed to theme.');
       return AsyncExpression(this.theme(__exprs[0], __env));
-    }, 1);
+    }, 1,
+        docs: Docs("theme", "Loads and applies a [theme].\n",
+            [Param("symbol", "theme")]));
     addBuiltin(__env, const SchemeSymbol("color->css"), (__exprs, __env) {
       if (__exprs[0] is! Color)
         throw SchemeException('Argument of invalid type passed to color->css.');
       return SchemeString(this.colorToCss(__exprs[0]));
-    }, 1);
+    }, 1,
+        docs: Docs("color->css", "Converts [color] to a string of CSS.\n",
+            [Param("color", "color")],
+            returnType: "string"));
   }
 }

--- a/lib/src/web/web_library.g.dart
+++ b/lib/src/web/web_library.g.dart
@@ -28,7 +28,7 @@ abstract class _$WebLibraryMixin {
   void importAll(Frame __env) {
     addVariableBuiltin(__env, const SchemeSymbol("js"), (__exprs, __env) {
       return this.js(__exprs);
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol("js-context"), (__exprs, __env) {
       return this.jsContext();
     }, 0);
@@ -44,11 +44,11 @@ abstract class _$WebLibraryMixin {
     }, 2);
     addVariableBuiltin(__env, const SchemeSymbol("js-call"), (__exprs, __env) {
       return this.jsCall(__exprs);
-    }, 2, -1);
+    }, 2, maxArgs: -1);
     addVariableBuiltin(__env, const SchemeSymbol("js-object"),
         (__exprs, __env) {
       return this.jsObject(__exprs);
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol("js-object?"), (__exprs, __env) {
       return Boolean(this.isJsObject(__exprs[0]));
     }, 1);
@@ -105,7 +105,7 @@ abstract class _$WebLibraryMixin {
     }, 1);
     addVariableBuiltin(__env, const SchemeSymbol('import'), (__exprs, __env) {
       return AsyncExpression(this.schemeImport(__exprs, __env));
-    }, 0, -1);
+    }, 0, maxArgs: -1);
     addBuiltin(__env, const SchemeSymbol('import-inline'), (__exprs, __env) {
       return AsyncExpression(this.schemeImportInline(__exprs[0], __env));
     }, 1);

--- a/lib/styles/_diagram.scss
+++ b/lib/styles/_diagram.scss
@@ -159,7 +159,7 @@
   .md-docs {
     @extend .docs;
     padding-left: 0.5em;
-    padding-right: 0.5em;
+    padding-right: 0.25em;
   }
 
   .diagram {

--- a/lib/styles/_diagram.scss
+++ b/lib/styles/_diagram.scss
@@ -103,12 +103,13 @@
     margin: 0.5em;
     border-radius: 0.185em;
     width: 80ch;
-    font-size: 110%;
+    font-size: 90%;
+    display: block;
     @include other-frame;
 
     .comment {
-      padding-left: 2px;
-      padding-right: 2px;
+      padding-left: 0.125em;
+      padding-right: 0.125em;
       display: inline-block;
     }
 
@@ -146,9 +147,19 @@
       content: ' ';
     }
 
+    .no-padding {
+      text-align: left;
+    }
+
     .no-padding::before {
       content: '';
     }
+  }
+
+  .md-docs {
+    @extend .docs;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
   }
 
   .diagram {

--- a/lib/styles/_diagram.scss
+++ b/lib/styles/_diagram.scss
@@ -98,6 +98,59 @@
     }
   }
 
+  .docs {
+    padding: 0.375em;
+    margin: 0.5em;
+    border-radius: 0.185em;
+    width: 80ch;
+    font-size: 110%;
+    @include other-frame;
+
+    .comment {
+      padding-left: 2px;
+      padding-right: 2px;
+      display: inline-block;
+    }
+
+    .usage {
+      margin-bottom: 8px;
+      border-collapse: collapse;
+    }
+
+    td {
+      vertical-align: super;
+      font-size: xx-small;
+      text-align: center;
+      font-style: italic;
+    }
+
+    .ret-type {
+      font-style: italic;
+      opacity: 0.7;
+    }
+
+    .ret-type::before {
+      content: ' -> ';
+    }
+
+    td::before {
+      content: ' ';
+    }
+
+    th {
+      text-align: center;
+      vertical-align: top;
+    }
+
+    th::before {
+      content: ' ';
+    }
+
+    .no-padding::before {
+      content: '';
+    }
+  }
+
   .diagram {
 
     .frames{

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -70,7 +70,7 @@ checkBuilt(String name) async {
 
 checkDocs() async {
   String source = await File("lib/src/core/documentation.md").readAsString();
-  String code = generateDocumentation(source);
+  String code = DartFormatter().format(generateDocumentation(source));
   String exist = await File('lib/src/core/documentation.g.dart').readAsString();
   if (code != exist) {
     print('Generated documentation is out of sync!');

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -19,6 +19,7 @@ build() async {
   for (var lib in libraries) {
     await buildLibrary(lib);
   }
+  await buildDocs();
 }
 
 @Task('Check that generated code is in sync.')
@@ -27,10 +28,18 @@ check() async {
   for (var lib in libraries) {
     good = await checkBuilt(lib) && good;
   }
+  good = await checkDocs();
   if (!good) {
     print('Run `pub run grinder` to keep generated code in sync.');
     exit(1);
   }
+}
+
+buildDocs() async {
+  String source = await File("lib/src/core/documentation.md").readAsString();
+  String code = generateDocumentation(source);
+  await File('lib/src/core/documentation.g.dart')
+      .writeAsString(DartFormatter().format(code));
 }
 
 buildLibrary(String name) async {
@@ -54,6 +63,17 @@ checkBuilt(String name) async {
   String existing = await output.readAsString();
   if (code != existing) {
     print('Generated code for $name out of sync!');
+    return false;
+  }
+  return true;
+}
+
+checkDocs() async {
+  String source = await File("lib/src/core/documentation.md").readAsString();
+  String code = generateDocumentation(source);
+  String exist = await File('lib/src/core/documentation.g.dart').readAsString();
+  if (code != exist) {
+    print('Generated documentation is out of sync!');
     return false;
   }
   return true;

--- a/web/main.dart
+++ b/web/main.dart
@@ -17,6 +17,7 @@ const String motd = "**61A Scheme Web Interpreter 2.0.0-beta**"
 `(visualize some-code)` to create an environment diagram [Try It](:try-viz)
 
 **Other Useful Commands**
+`(docs symbol)` to display documentation for some built-in or special form
 `(clear)` to clear all output on the screen
 `(theme 'id)` to change the interpreter's theme
 [default](:try-default) [solarized](:try-solarized) """


### PR DESCRIPTION
Closes #4.

Doc comments and type information are now stored in the generated libraries by the builder.

There's also a new `documentation.md` file, which is built into additional miscellaneous documentation (mostly for special forms).

Documentation can then be referenced by calling `(docs <topic>)`. You can view all available documentation with `(all-docs)`.