### PR TITLE
Add function to utils to find documented forms

### DIFF
--- a/lib/src/core/utils.dart
+++ b/lib/src/core/utils.dart
@@ -99,3 +99,18 @@ int countParens(String text) {
 
 Future delay(int milliseconds) =>
     Future.delayed(Duration(milliseconds: milliseconds));
+
+Map<String, Docs> allDocumentedForms(Frame env) {
+  var forms = <String, Docs>{};
+  for (var value in env.bindings.values) {
+    if (value is Procedure && value.docs != null) {
+      forms[value.name.value] = value.docs;
+    }
+  }
+  for (var special in env.interpreter.specialForms.keys) {
+    if (miscDocumentation.containsKey(special.value)) {
+      forms[special.value] = miscDocumentation[special.value];
+    }
+  }
+  return forms;
+}


### PR DESCRIPTION
`allDocumentedForms` takes in a frame (which should usually be the global frame) and returns a mapping from some form (either a built-in procedure or a special form) to the corresponding documentation.

@dnachum: This should be useful for implementing autocomplete