### PR TITLE
Major refactor of data types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 - unzip master.zip
 - mv scheme_impl_skeleton-master dart_scheme_impl
 - cd dart_scheme_impl
-- wget -O lib/impl.dart $PRIVATE_IMPL || export NO_IMPL="-x impl"
+- wget -O lib/impl.dart "$PRIVATE_IMPL_BASE/0300ce8b555bdc0851cc05ebcbfa6490fb91a599/impl.dart" || export NO_IMPL="-x impl"
 - cd $TRAVIS_BUILD_DIR
 script:
 - pub run test $NO_IMPL

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -65,6 +65,7 @@ class BuiltinStub {
   String returnType;
   List<String> paramTypes;
   List<String> paramNames;
+  String variableType;
   bool needsEnvironment = false;
 
   String comment;
@@ -112,6 +113,7 @@ class BuiltinStub {
   String _makeFunction() {
     if (variableArity &&
         needsEnvironment &&
+        variableType == 'Value' &&
         !returnConversions.containsKey(returnType) &&
         returnType != 'void') return "this.$methodName";
     String before = needsTurtle ? "turtle.show();" : "";
@@ -136,14 +138,21 @@ class BuiltinStub {
   }
 
   String _makeChecks() {
-    if (variableArity) return "";
     var checks = [];
-    for (int i = 0; i < paramTypes.length; i++) {
-      var type = paramTypes[i];
-      if (typeChecks.containsKey(paramTypes[i])) {
+    if (variableArity) {
+      var type = variableType;
+      if (typeChecks.containsKey(type)) {
         type = typeChecks[type];
       }
-      if (type != 'Expression') checks.add("__exprs[$i] is! $type");
+      if (type != 'Value') checks.add("__exprs.any((x) => x is! $type)");
+    } else {
+      for (int i = 0; i < paramTypes.length; i++) {
+        var type = paramTypes[i];
+        if (typeChecks.containsKey(type)) {
+          type = typeChecks[type];
+        }
+        if (type != 'Value') checks.add("__exprs[$i] is! $type");
+      }
     }
     if (checks.isEmpty) return "";
     var decodeName = name.substring(1, name.length - 1);
@@ -152,31 +161,48 @@ class BuiltinStub {
   }
 
   String _makeParams() {
-    if (variableArity) return needsEnvironment ? "__exprs, __env" : "__exprs";
     var params = [];
-    for (int i = 0; i < paramTypes.length; i++) {
-      var param = '__exprs[$i]';
-      switch (paramTypes[i]) {
-        case 'int':
-          param = '$param.toJS().toInt()';
-          break;
-        case 'double':
-          param = '$param.toJS().toDouble()';
-          break;
-        case 'num':
-          param = '$param.toJS()';
-          break;
-        case 'bool':
-          param = '$param.isTruthy';
-          break;
-        case 'String':
-          param = '($param as SchemeString).value';
-          break;
+    if (variableArity) {
+      var param = "__exprs";
+      var type = variableType;
+      if (typeChecks.containsKey(type)) {
+        type = typeChecks[type];
+      }
+      if (type != 'Value') param += ".cast<$type>()";
+      var converted = _convertParam('x', variableType);
+      if (converted != 'x') {
+        param += '.map((x) => $converted).toList()';
       }
       params.add(param);
+    } else {
+      for (int i = 0; i < paramTypes.length; i++) {
+        var param = _convertParam('__exprs[$i]', paramTypes[i]);
+        params.add(param);
+      }
     }
     if (needsEnvironment) params.add("__env");
     return params.join(',');
+  }
+
+  String _convertParam(String param, String type) {
+    switch (type) {
+      case 'int':
+        param = '$param.toJS().toInt()';
+        break;
+      case 'double':
+        param = '$param.toJS().toDouble()';
+        break;
+      case 'num':
+        param = '$param.toJS()';
+        break;
+      case 'bool':
+        param = '$param.isTruthy';
+        break;
+      case 'String':
+        param = '($param as SchemeString).value';
+        break;
+    }
+    return param;
   }
 
   String _wrapReturn(String call) {
@@ -201,10 +227,12 @@ class BuiltinStub {
     'Procedure': 'procedure',
     'Pair': 'pair',
     'SchemeEventListener': 'event listener',
-    'JsExpression': 'js object',
+    'JsValue': 'js object',
     'JsProcedure': 'js function',
     'Color': 'color',
-    'ImportedLibrary': 'library'
+    'ImportedLibrary': 'library',
+    'Value': 'value',
+    'Expression': 'expression'
   };
 
   static const Map<String, String> typeChecks = {
@@ -221,9 +249,9 @@ class BuiltinStub {
     'num': 'Number.fromNum',
     'String': 'SchemeString',
     'bool': 'Boolean',
-    'Future<Expression>': 'AsyncExpression',
+    'Future<Value>': 'AsyncValue',
     'JsFunction': 'JsProcedure',
-    'JsObject': 'JsExpression'
+    'JsObject': 'JsValue'
   };
 }
 
@@ -274,12 +302,14 @@ BuiltinStub _buildStub(MethodDeclaration method) {
   }
   stub.name ??= json.encode(method.name.toSource().toLowerCase());
   stub.returnType = method.returnType.toSource();
-  bool takesListExpr = _isVariableArity(method);
-  if (stub.variableArity && !takesListExpr) {
-    throw Exception("Built-ins with fixed arguments can have min/max");
+  var variableType = _findVariableArityType(method);
+  if (stub.variableArity && variableType == null) {
+    print(method);
+    throw Exception("Built-ins with fixed arguments can't have min/max");
   }
-  stub.variableArity = takesListExpr;
+  stub.variableArity = variableType != null;
   if (stub.variableArity) {
+    stub.variableType = variableType;
     int paramCount = method.parameters.parameters.length;
     if (paramCount != 1 && paramCount != 2) {
       throw Exception("${stub.name} has an invalid number of parameters!");
@@ -320,18 +350,18 @@ List<String> _paramNames(MethodDeclaration method) {
   return names;
 }
 
-bool _isVariableArity(MethodDeclaration method) {
-  if (method.parameters.parameters.isNotEmpty) {
-    FormalParameter param = method.parameters.parameters[0];
-    if (param is SimpleFormalParameter) {
-      if (param.type.toSource() == "List<Expression>") {
-        return true;
-      }
-    } else {
-      throw Exception("Built-in procedures may not have optional parameters.");
-    }
+String _findVariableArityType(MethodDeclaration method) {
+  if (method.parameters.parameters.isEmpty) return null;
+  FormalParameter param = method.parameters.parameters[0];
+  if (param is! SimpleFormalParameter) {
+    throw Exception("Built-in procedures may not have optional parameters.");
   }
-  return false;
+  TypeAnnotation paramType = (param as SimpleFormalParameter).type;
+  if (paramType is! NamedType) return null;
+  NamedType namedType = paramType as NamedType;
+  if (namedType.name.toSource() != 'List') return null;
+  if ((namedType.typeArguments?.length ?? 0) == 0) return null;
+  return namedType.typeArguments.arguments[0].toSource();
 }
 
 String generateDocumentation(String markdownSource) {

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -143,6 +143,8 @@ class BuiltinStub {
       var type = variableType;
       if (typeChecks.containsKey(type)) {
         type = typeChecks[type];
+      } else if (type.startsWith('SchemeList')) {
+        type = 'PairOrEmpty';
       }
       if (type != 'Value') checks.add("__exprs.any((x) => x is! $type)");
     } else {
@@ -150,6 +152,8 @@ class BuiltinStub {
         var type = paramTypes[i];
         if (typeChecks.containsKey(type)) {
           type = typeChecks[type];
+        } else if (type.startsWith('SchemeList')) {
+          type = 'PairOrEmpty';
         }
         if (type != 'Value') checks.add("__exprs[$i] is! $type");
       }
@@ -202,12 +206,18 @@ class BuiltinStub {
         param = '($param as SchemeString).value';
         break;
     }
+    if (type.startsWith('SchemeList')) {
+      param = '$type($param)';
+    }
     return param;
   }
 
   String _wrapReturn(String call) {
     if (returnConversions.containsKey(returnType)) {
       return '${returnConversions[returnType]}($call)';
+    }
+    if (returnType.startsWith('SchemeList')) {
+      return '($call).list';
     }
     return call;
   }

--- a/lib/cs61a_scheme.dart
+++ b/lib/cs61a_scheme.dart
@@ -8,6 +8,7 @@ library cs61a_scheme.core;
 
 export 'src/core/documentation.dart';
 export 'src/core/expressions.dart';
+export 'src/core/frame.dart';
 export 'src/core/interpreter.dart';
 export 'src/core/logging.dart';
 export 'src/core/numbers.dart';
@@ -18,4 +19,5 @@ export 'src/core/scheme_library.dart';
 export 'src/core/serialization.dart';
 export 'src/core/standard_library.dart';
 export 'src/core/utils.dart';
+export 'src/core/values.dart';
 export 'src/core/widgets.dart';

--- a/lib/cs61a_scheme.dart
+++ b/lib/cs61a_scheme.dart
@@ -21,3 +21,4 @@ export 'src/core/standard_library.dart';
 export 'src/core/utils.dart';
 export 'src/core/values.dart';
 export 'src/core/widgets.dart';
+export 'src/core/wrappers.dart';

--- a/lib/logic.dart
+++ b/lib/logic.dart
@@ -195,7 +195,8 @@ class _LogicRun {
     if (depth > depthLimit) return;
     Pair clause = clauses.first;
     if (clause.first == not) {
-      var grounded = ground(clause.second, env).pair.map((expr) => expr.pair);
+      var grounded = SchemeList.fromValue(ground(clause.second, env))
+          .map((expr) => expr.pair);
       if (search(grounded, env, depth).isEmpty) {
         var envHead = LogicEnv(env);
         yield* search(clauses.skip(1), envHead, depth + 1);

--- a/lib/src/core/expressions.dart
+++ b/lib/src/core/expressions.dart
@@ -5,65 +5,23 @@ import 'dart:convert' show json;
 
 import 'package:quiver/core.dart';
 
-import 'interpreter.dart';
+import 'frame.dart';
 import 'logging.dart';
 import 'serialization.dart';
 import 'utils.dart';
+import 'values.dart';
 import 'widgets.dart';
 
-/// Base class for all Scheme data types.
-///
-/// Everything that can be touched by Scheme code should inherit from this.
-abstract class Expression {
+/// Base class for all Scheme values that can be evaluated.
+abstract class Expression extends Value {
   const Expression();
 
   /// Evaluates this expression in [env].
-  Expression evaluate(Frame env);
-
-  /// All Scheme expressions are truthy except for the [Boolean] `#f`.
-  bool get isTruthy => true;
-
-  /// Determines how this expression is represented in environment diagrams.
-  ///
-  /// If true, this expression should be inlined in diagrams.
-  /// If false, it should be added to the objects with an arrow to it.
-  bool get inlineInDiagram => false;
-
-  /// Constructs a [Widget] for this expression.
-  ///
-  /// The default implementation returns the string representation of this
-  /// expression as a [TextWidget]. Some expressions may need to add
-  /// additional objects to [diagram].
-  Widget draw(DiagramInterface diagram) => TextWidget(toString());
-
-  /// Shorthand for `expr is EmptyList`.
-  bool get isNil => false;
-
-  /// Defines how this expression should be displayed.
-  ///
-  /// Used by the `(display <expr>)` built-in. Defaults to [toString].
-  String get display => toString();
-
-  /// Should return a version of this object that can be passed to JS.
-  ///
-  /// The default implementation just returns the expression itself, so this
-  /// should be overridden if passing to JS is intended.
-  dynamic toJS() => this;
-
-  /// Convenience function since casting as a Pair is very common.
-  Pair get pair => this as Pair;
-}
-
-/// An expression that evaluates to itself. Common for literals.
-abstract class SelfEvaluating extends Expression {
-  const SelfEvaluating();
-
-  /// This expression evaluates to itself.
-  Expression evaluate(Frame env) => this;
+  Value evaluate(Frame env);
 }
 
 /// A Scheme boolean. There are only two: [schemeTrue] and [schemeFalse].
-class Boolean extends SelfEvaluating implements Serializable<Boolean> {
+class Boolean extends Expression implements Serializable<Boolean> {
   final bool value;
   const Boolean._internal(this.value);
 
@@ -71,6 +29,8 @@ class Boolean extends SelfEvaluating implements Serializable<Boolean> {
   ///
   /// Additional [Boolean] expressions will never be created.
   factory Boolean(bool value) => value ? schemeTrue : schemeFalse;
+
+  Value evaluate(Frame env) => this;
 
   bool get isTruthy => value;
   bool get inlineInDiagram => true;
@@ -100,7 +60,7 @@ class SchemeSymbol extends Expression implements Serializable<SchemeSymbol> {
 
   const SchemeSymbol(this.value);
   SchemeSymbol.runtime(String value) : this.value = value.toLowerCase();
-  Expression evaluate(Frame env) => env.lookup(this);
+  Value evaluate(Frame env) => env.lookup(this);
   bool get inlineInDiagram => true;
   toString() => value;
   operator ==(other) => other is SchemeSymbol && value == other.value;
@@ -112,10 +72,12 @@ class SchemeSymbol extends Expression implements Serializable<SchemeSymbol> {
 }
 
 /// A Scheme string.
-class SchemeString extends SelfEvaluating
-    implements Serializable<SchemeString> {
+class SchemeString extends Expression implements Serializable<SchemeString> {
   final String value;
   const SchemeString(this.value);
+
+  Value evaluate(Frame env) => this;
+
   toString() => json.encode(value);
   bool get inlineInDiagram => true;
 
@@ -129,8 +91,8 @@ class SchemeString extends SelfEvaluating
   SchemeString deserialize(Map data) => SchemeString(data['value']);
 }
 
-class _SchemeListIterator extends Iterator<Expression> {
-  Expression current;
+class _SchemeListIterator extends Iterator<Value> {
+  Value current;
   Pair pair;
   _SchemeListIterator(this.pair) {
     if (!pair.wellFormed) throw TypeError();
@@ -145,7 +107,7 @@ class _SchemeListIterator extends Iterator<Expression> {
   }
 }
 
-class _NilIterator extends Iterator<Expression> {
+class _NilIterator extends Iterator<Value> {
   get current => null;
   moveNext() => false;
 }
@@ -157,11 +119,11 @@ class _NilIterator extends Iterator<Expression> {
 /// doesn't have union types, we instead use this interface.
 ///
 /// Iterating over this class will fail if [wellFormed] is false.
-abstract class PairOrEmpty extends Expression implements Iterable<Expression> {
+abstract class PairOrEmpty extends Expression implements Iterable<Value> {
   /// Creates a Scheme list from the given Dart iterable.
-  factory PairOrEmpty.fromIterable(Iterable<Expression> iterable) {
+  factory PairOrEmpty.fromIterable(Iterable<Value> iterable) {
     PairOrEmpty result = nil;
-    for (Expression item in iterable.toList().reversed) {
+    for (Value item in iterable.toList().reversed) {
       result = Pair(item, result);
     }
     return result;
@@ -181,8 +143,8 @@ abstract class PairOrEmpty extends Expression implements Iterable<Expression> {
 ///
 /// This can't use [IterableMixin] because we need it to have a constant
 /// constructor, so we have to implement all the [Iterable] methods ourselves.
-class _EmptyList extends IterableBase<Expression>
-    implements SelfEvaluating, PairOrEmpty {
+class _EmptyList extends IterableBase<Value>
+    implements Expression, PairOrEmpty {
   const _EmptyList();
   bool get inlineInDiagram => true;
   bool get wellFormed => true;
@@ -196,7 +158,7 @@ class _EmptyList extends IterableBase<Expression>
 
   get display => toString();
   draw(DiagramInterface diagram) => TextWidget('()');
-  evaluate(Frame env) => this;
+  Value evaluate(Frame env) => this;
   get isTruthy => true;
   get pair => this as Pair;
   toJS() => this;
@@ -207,12 +169,12 @@ const nil = _EmptyList();
 
 /// A Scheme pair.
 ///
-/// A pair of two expressions. When [second] is either [nil] or another pair,
+/// A pair of two values. When [second] is either [nil] or another pair,
 /// this is a well-formed Scheme list and can be iterated over.
 ///
 /// [first] is the `car`. [second] is the `cdr`.
-class Pair<A extends Expression, B extends Expression> extends Expression
-    with IterableMixin<Expression>
+class Pair<A extends Value, B extends Value> extends Expression
+    with IterableMixin<Value>
     implements PairOrEmpty {
   A first;
   B second;
@@ -243,9 +205,9 @@ class Pair<A extends Expression, B extends Expression> extends Expression
     return length + (fast is Pair ? 1 : 0);
   }
 
-  Iterator<Expression> get iterator => _SchemeListIterator(this);
+  Iterator<Value> get iterator => _SchemeListIterator(this);
 
-  Expression evaluate(Frame env) => evalCallExpression(this, env);
+  Value evaluate(Frame env) => evalCallExpression(this, env);
 
   @override
   Widget draw(DiagramInterface diagram) {
@@ -281,10 +243,10 @@ class Pair<A extends Expression, B extends Expression> extends Expression
   ///
   /// The last argument can be any expression. If it is not a Scheme list, the
   /// resulting appended list will be dotted with it.
-  static Expression append(List<Expression> args) {
+  static Expression append(List<Value> args) {
     if (args.isEmpty) return nil;
-    List<Expression> lst = [];
-    for (Expression arg in args.take(args.length - 1)) {
+    List<Value> lst = [];
+    for (Value arg in args.take(args.length - 1)) {
       if (arg.isNil) continue;
       if (arg is Pair && arg.wellFormed) {
         lst.addAll(arg);
@@ -293,173 +255,15 @@ class Pair<A extends Expression, B extends Expression> extends Expression
       }
     }
     PairOrEmpty result = nil;
-    Expression lastArg = args.last;
+    Value lastArg = args.last;
     if (lastArg is PairOrEmpty && lastArg.wellFormed) {
       lst.addAll(lastArg);
     } else {
       result = lastArg;
     }
-    for (Expression expr in lst.reversed) {
-      result = Pair(expr, result);
+    for (Value val in lst.reversed) {
+      result = Pair(val, result);
     }
     return result;
   }
-}
-
-/// Singleton class for [undefined].
-class Undefined extends SelfEvaluating {
-  const Undefined._internal();
-  toString() => "undefined";
-
-  /// If the web library has been loaded, this returns the JS value `undefined`.
-  ///
-  /// Otherwise, it returns null.
-  toJS() => Undefined.jsUndefined;
-
-  /// Initialized to the JS value `undefined` when the web library is loaded.
-  static dynamic jsUndefined;
-}
-
-/// Represents undefined values in Scheme, like `(if #f 1)`.
-const undefined = Undefined._internal();
-
-/// An expression to be evaluated in an environment.
-///
-/// Used internally for tail-call optimization. Should not be output.
-class Thunk extends Expression {
-  final Expression expr;
-  final Frame env;
-  const Thunk(this.expr, this.env);
-  Expression evaluate(Frame _) {
-    List<Expression> expressions = [];
-    try {
-      Expression result = this;
-      while (result is Thunk) {
-        Thunk thunk = result as Thunk;
-        expressions.insert(0, thunk.expr);
-        result = thunk.expr.evaluate(thunk.env);
-      }
-      return result;
-    } on SchemeException catch (e) {
-      expressions.forEach(e.addCall);
-      rethrow;
-    }
-  }
-
-  toJS() => throw StateError("Thunks should not be passed to JS");
-  toString() => 'Thunk($expr in f${env.id})';
-}
-
-/// A Scheme promise, used for Scheme streams.
-///
-/// A Scheme promise is a delayed expression that will be evaluated when forced.
-/// Once forced, the result is cached and returned directly when forced again.
-///
-/// Scheme promises are primarily used for created Scheme streams. A Scheme
-/// stream is the lazy equivalent of a Scheme list and is defined as a pair
-/// whose cdr is a promise that evaluates to another stream or the empty list.
-///
-/// It is semantically different from a JS Promise, which is equivalent to a
-/// Dart [Future]. The Scheme equivalent of [Future] is [AsyncExpression].
-///
-/// A Scheme stream is semantically different from a Dart Stream, which is an
-/// asynchronous sequence. A Scheme stream is analogous to a lazily-computed
-/// iterable built on a linked list.
-class Promise extends SelfEvaluating {
-  Expression expr;
-  final Frame env;
-  bool _evaluated = false;
-  Promise(this.expr, this.env);
-
-  /// Evaluates the promise, or returns the result if already evaluated.
-  Expression force() {
-    if (!_evaluated) {
-      expr = schemeEval(expr, env);
-      _evaluated = true;
-    }
-    return expr;
-  }
-
-  toString() => "#[promise (${_evaluated ? '' : 'not '}forced)]";
-  @override
-
-  /// Promises are represented in diagrams as a circle with ⋯ inside prior to
-  /// forcing, and the evaluated result afterwards.
-  Widget draw(DiagramInterface diagram) {
-    var inside = _evaluated ? diagram.pointTo(expr) : TextWidget("⋯");
-    return Block.promise(inside);
-  }
-}
-
-/// A Scheme environment.
-///
-/// This consists of a set of [bindings] between [SchemeSymbol] identifiers and
-/// [Expression] values, as well as a [parent]. When looking up a symbol, the
-/// current bindings map is checked first, before recursively checking the
-/// parent frame.
-///
-/// This also maintains a reference to the [Interpreter] it is part of, which
-/// allows any function that takes in a [Frame] to access core interpreter
-/// functionality (like logging and the project implementation).
-///
-/// Within an interpreter, there is a single global frame with [id] equal to 0
-/// and [parent] equal to null. All frames should inherit from the global frame
-/// either directly or through a chain of parent frames.
-class Frame extends SelfEvaluating {
-  /// The parent of this frame. This is null for the global frame.
-  Frame parent;
-
-  /// The interpreter this frame is part of.
-  Interpreter interpreter;
-
-  /// Optional human-readable name for this frame.
-  ///
-  /// Set to the intrinsic name of the called function when this frame was
-  /// created through a procedure call.
-  String tag;
-
-  /// Unique identifier for this frame in the interpreter.
-  ///
-  /// The global frame has id 0. All other frame are numbered sequentially.
-  int id;
-
-  /// True if this frame was created by a MacroProcedure.
-  bool fromMacro = false;
-
-  /// Mapping of symbols to values.
-  Map<SchemeSymbol, Expression> bindings = {};
-
-  /// Stores whether a given symbol should be hidden from environment diagrams.
-  Map<SchemeSymbol, bool> hidden = {};
-
-  /// Creates a new frame with the next sequential id.
-  Frame(this.parent, this.interpreter) : id = interpreter.frameCounter++;
-
-  /// Creates a new binding between [symbol] and [value] in this frame.
-  ///
-  /// If hide is true, this binding will be hidden from environment diagrams.
-  void define(SchemeSymbol symbol, Expression value, [bool hide = false]) {
-    interpreter.impl.defineInFrame(symbol, value, this);
-    hidden[symbol] = hide;
-  }
-
-  /// Looks up the given symbol in this or a parent frame.
-  Expression lookup(SchemeSymbol symbol) =>
-      interpreter.impl.lookupInFrame(symbol, this);
-
-  /// Changes an existing binding to a new value in this or a parent frame.
-  ///
-  /// If the symbol is not bound, throws a [SchemeException].
-  void update(SchemeSymbol symbol, Expression value) {
-    if (bindings.containsKey(symbol)) {
-      bindings[symbol] = value;
-      return;
-    }
-    if (parent == null) throw SchemeException("$symbol is not bound");
-    parent.update(symbol, value);
-  }
-
-  /// Creates a frame with this as its parent and all [formals] bound to [vals].
-  Frame makeChildFrame(Expression formals, Expression vals) =>
-      interpreter.impl.makeChildOf(formals, vals, this);
 }

--- a/lib/src/core/frame.dart
+++ b/lib/src/core/frame.dart
@@ -4,6 +4,7 @@ import 'expressions.dart';
 import 'interpreter.dart';
 import 'logging.dart';
 import 'values.dart';
+import 'wrappers.dart';
 
 /// A Scheme environment.
 ///
@@ -74,6 +75,6 @@ class Frame {
   }
 
   /// Creates a frame with this as its parent and all [formals] bound to [vals].
-  Frame makeChildFrame(Expression formals, Value vals) =>
+  Frame makeChildFrame(Expression formals, SchemeList vals) =>
       interpreter.impl.makeChildOf(formals, vals, this);
 }

--- a/lib/src/core/frame.dart
+++ b/lib/src/core/frame.dart
@@ -1,0 +1,79 @@
+library cs61a_scheme.core.frame;
+
+import 'expressions.dart';
+import 'interpreter.dart';
+import 'logging.dart';
+import 'values.dart';
+
+/// A Scheme environment.
+///
+/// This consists of a set of [bindings] between [SchemeSymbol] identifiers and
+/// [Value] values, as well as a [parent]. When looking up a symbol, the
+/// current bindings map is checked first, before recursively checking the
+/// parent frame.
+///
+/// This also maintains a reference to the [Interpreter] it is part of, which
+/// allows any function that takes in a [Frame] to access core interpreter
+/// functionality (like logging and the project implementation).
+///
+/// Within an interpreter, there is a single global frame with [id] equal to 0
+/// and [parent] equal to null. All frames should inherit from the global frame
+/// either directly or through a chain of parent frames.
+class Frame {
+  /// The parent of this frame. This is null for the global frame.
+  Frame parent;
+
+  /// The interpreter this frame is part of.
+  Interpreter interpreter;
+
+  /// Optional human-readable name for this frame.
+  ///
+  /// Set to the intrinsic name of the called function when this frame was
+  /// created through a procedure call.
+  String tag;
+
+  /// Unique identifier for this frame in the interpreter.
+  ///
+  /// The global frame has id 0. All other frame are numbered sequentially.
+  int id;
+
+  /// True if this frame was created by a MacroProcedure.
+  bool fromMacro = false;
+
+  /// Mapping of symbols to values.
+  Map<SchemeSymbol, Value> bindings = {};
+
+  /// Stores whether a given symbol should be hidden from environment diagrams.
+  Map<SchemeSymbol, bool> hidden = {};
+
+  /// Creates a new frame with the next sequential id.
+  Frame(this.parent, this.interpreter) : id = interpreter.frameCounter++;
+
+  /// Creates a new binding between [symbol] and [value] in this frame.
+  ///
+  /// If hide is true, this binding will be hidden from environment diagrams.
+  void define(SchemeSymbol symbol, Value value, [bool hide = false]) {
+    interpreter.impl.defineInFrame(symbol, value, this);
+    hidden[symbol] = hide;
+  }
+
+  /// Looks up the given symbol in this or a parent frame.
+  Value lookup(SchemeSymbol symbol) =>
+      interpreter.impl.lookupInFrame(symbol, this);
+
+  /// Changes an existing binding to a new value in this or a parent frame.
+  ///
+  /// If the symbol is not bound, throws a [SchemeException].
+  void update(SchemeSymbol symbol, Value value) {
+    if (bindings.containsKey(symbol)) {
+      bindings[symbol] = value;
+      return;
+    }
+    if (parent == null) throw SchemeException("$symbol is not bound");
+    parent.update(symbol, value);
+  }
+
+  /// Creates a frame with this as its parent and all [formals] bound to [vals].
+  Frame makeChildFrame(Expression formals, Value vals) =>
+      interpreter.impl.makeChildOf(formals, vals, this);
+}

--- a/lib/src/core/interpreter.dart
+++ b/lib/src/core/interpreter.dart
@@ -1,6 +1,7 @@
 library cs61a_scheme.core.interpreter;
 
 import 'expressions.dart';
+import 'frame.dart';
 import 'logging.dart';
 import 'procedures.dart';
 import 'project_interface.dart';
@@ -9,6 +10,7 @@ import 'scheme_library.dart';
 import 'special_forms.dart';
 import 'standard_library.dart';
 import 'utils.dart' show schemeEval;
+import 'values.dart';
 
 class Interpreter {
   final ProjectInterface impl;
@@ -37,7 +39,7 @@ class Interpreter {
 
   final Map<SchemeSymbol, List<SchemeBuiltin>> _eventListeners = {};
 
-  void triggerEvent(SchemeSymbol id, List<Expression> data, Frame env) {
+  void triggerEvent(SchemeSymbol id, List<Value> data, Frame env) {
     if (_eventListeners.containsKey(id)) {
       for (var blocker in _eventListeners[id]) {
         blocker(data.toList(), env);
@@ -69,7 +71,7 @@ class Interpreter {
     while (_tokens.isNotEmpty) {
       try {
         Expression expr = schemeRead(_tokens, impl);
-        Expression result = schemeEval(expr, globalEnv);
+        Value result = schemeEval(expr, globalEnv);
         if (!identical(result, undefined)) logger(result, true);
       } on SchemeException catch (e) {
         logger(e, true);

--- a/lib/src/core/logging.dart
+++ b/lib/src/core/logging.dart
@@ -1,9 +1,11 @@
 library cs61a_scheme.core.logging;
 
 import 'expressions.dart';
+import 'frame.dart';
+import 'values.dart';
 
-/// Logs [expr] somewhere with a new line if [addNewLine] is true.
-typedef Logger = void Function(Expression expr, bool addNewLine);
+/// Logs [value] somewhere with a new line if [addNewLine] is true.
+typedef Logger = void Function(Value value, bool addNewLine);
 
 /// Given two loggers, returns a new one that calls both.
 Logger combineLoggers(Logger a, Logger b) => (e, addNewLine) {
@@ -11,20 +13,20 @@ Logger combineLoggers(Logger a, Logger b) => (e, addNewLine) {
       b(e, addNewLine);
     };
 
-/// Scheme expression representing an expression to be displayed.
+/// Scheme value representing a value to be displayed.
 ///
 /// Used by the built-in `display` Scheme procedure.
-class DisplayOutput extends SelfEvaluating {
-  final Expression expression;
-  const DisplayOutput(this.expression);
-  toString() => expression.display;
-  toJS() => expression.toJS();
+class DisplayOutput extends Value {
+  final Value value;
+  const DisplayOutput(this.value);
+  toString() => value.display;
+  toJS() => value.toJS();
 }
 
-/// Scheme expression representing text to be outputted.
+/// Scheme value representing text to be outputted.
 ///
 /// Used for logging.
-class TextMessage extends SelfEvaluating {
+class TextMessage extends Value {
   final String message;
   const TextMessage(this.message);
   toString() => message;
@@ -37,11 +39,11 @@ class TextMessage extends SelfEvaluating {
 /// code. While other Dart errors will still be caught by the outer interpreter
 /// loop, throwing a [SchemeException] ensures that the logged stack trace is
 /// for Scheme, not Dart/JS.
-class SchemeException extends SelfEvaluating implements Exception {
+class SchemeException extends Value implements Exception {
   final String message;
   final bool showTrace;
   final Expression context;
-  final List<Expression> callStack = [];
+  final List<Value> callStack = [];
   SchemeException([this.message, this.showTrace = true, this.context]);
 
   toString() {
@@ -54,7 +56,7 @@ class SchemeException extends SelfEvaluating implements Exception {
   }
 
   // Adds [expr] to the stack trace of this exception.
-  addCall(Expression expr) {
+  addCall(Value expr) {
     callStack.insert(0, expr);
   }
 }

--- a/lib/src/core/numbers.dart
+++ b/lib/src/core/numbers.dart
@@ -1,8 +1,10 @@
 library cs61a_scheme.core.numbers;
 
 import 'expressions.dart';
+import 'frame.dart';
 import 'logging.dart';
 import 'serialization.dart';
+import 'values.dart';
 
 /// Base class for both Scheme number types.
 ///
@@ -12,7 +14,7 @@ import 'serialization.dart';
 ///
 /// With the exception of true division, all arithmetic operations between two
 /// [Integer] expressions should return another [Integer].
-abstract class Number extends SelfEvaluating {
+abstract class Number extends Expression {
   Number();
 
   /// Create a new [Number] from a Dart [num].
@@ -37,6 +39,8 @@ abstract class Number extends SelfEvaluating {
 
   bool get inlineInDiagram => true;
   dynamic get value;
+
+  Value evaluate(Frame env) => this;
 
   Number _operation(Number other, Function fn) {
     num myNum = this is Double ? value : num.parse("$this");
@@ -145,8 +149,3 @@ class Double extends Number implements Serializable<Double> {
   @override
   double toJS() => value;
 }
-
-/// Given an iterable of [Expression] objects, checks that they are all numbers
-/// and returns a new iterable will all of them casted as such.
-Iterable<Number> allNumbers(Iterable<Expression> expr) => expr.map(
-    (ex) => ex is Number ? ex : throw SchemeException("$ex is not a number."));

--- a/lib/src/core/project_interface.dart
+++ b/lib/src/core/project_interface.dart
@@ -3,7 +3,9 @@ library cs61a_scheme.core.project_interface;
 import 'dart:async';
 
 import 'expressions.dart';
+import 'frame.dart';
 import 'procedures.dart';
+import 'values.dart';
 
 /// Interface for the Scheme project implementation.
 ///
@@ -30,28 +32,26 @@ abstract class ProjectInterface {
   Expression read(List<Expression> tokens);
 
   /// Analagous to Frame.define and Frame.lookup in Problem 3
-  void defineInFrame(SchemeSymbol symbol, Expression value, Frame env);
-  Expression lookupInFrame(SchemeSymbol symbol, Frame env);
+  void defineInFrame(SchemeSymbol symbol, Value value, Frame env);
+  Value lookupInFrame(SchemeSymbol symbol, Frame env);
 
   /// Analagous to BuiltinProcedure.apply in Problem 4
-  Expression builtinApply(
-      BuiltinProcedure procedure, PairOrEmpty args, Frame env);
+  Value builtinApply(BuiltinProcedure procedure, PairOrEmpty args, Frame env);
 
   /// Analagous to part of scheme_eval implemented in Problem 5
-  Expression evalProcedureCall(Expression first, Expression rest, Frame env);
+  Value evalProcedureCall(Expression first, Expression rest, Frame env);
 
   /// Analagous to Procedure.eval_call in Problem 5
-  Expression procedureCall(
-      Procedure procedure, PairOrEmpty operands, Frame env);
+  Value procedureCall(Procedure procedure, PairOrEmpty operands, Frame env);
 
   /// Analagous to do_define_form in Problems 6 and 10
-  Expression doDefineForm(PairOrEmpty expressions, Frame env);
+  Value doDefineForm(PairOrEmpty expressions, Frame env);
 
   /// Analagous to do_quote_form in Problem 7
-  Expression doQuoteForm(PairOrEmpty expressions, Frame env);
+  Value doQuoteForm(PairOrEmpty expressions, Frame env);
 
   /// Analagous to eval_all in Problem 8
-  Expression evalAll(PairOrEmpty expressions, Frame env);
+  Value evalAll(PairOrEmpty expressions, Frame env);
 
   /// Analagous to do_lambda_form in Problem 9
   LambdaProcedure doLambdaForm(PairOrEmpty expressions, Frame env);
@@ -63,11 +63,11 @@ abstract class ProjectInterface {
   Frame makeLambdaFrame(LambdaProcedure procedure, PairOrEmpty args, Frame env);
 
   /// Analagous to do_and_form and do_or_form in Problem 13
-  Expression doAndForm(PairOrEmpty expressions, Frame env);
-  Expression doOrForm(PairOrEmpty expressions, Frame env);
+  Value doAndForm(PairOrEmpty expressions, Frame env);
+  Value doOrForm(PairOrEmpty expressions, Frame env);
 
   /// Analagous to part of do_cond_form in Problem 14
-  Expression evalCondResult(PairOrEmpty clause, Frame env, Expression test);
+  Value evalCondResult(PairOrEmpty clause, Frame env, Expression test);
 
   /// Analagous to make_let_frame in Problem 15
   Frame makeLetFrame(PairOrEmpty bindings, Frame env);
@@ -79,54 +79,45 @@ abstract class ProjectInterface {
   MuProcedure doMuForm(PairOrEmpty expressions, Frame env);
 
   /// Analagous to do_if_form, but with some changes from the spec
-  Expression doIfForm(PairOrEmpty expressions, Frame env);
+  Value doIfForm(PairOrEmpty expressions, Frame env);
 
   /// Analagous to scheme_optimized_eval with tail=True in Problem 20 (EC)
-  Expression tailEval(Expression expression, Frame env);
+  Value tailEval(Expression expression, Frame env);
 
-  /// Analagous to scheme_call_cc in Problem 21 (EC)
-  Expression callWithCurrentContinuation(Procedure procedure, Frame env);
+  /// Analagous to MacroProcedure.eval_call in Problem 21 (EC)
+  Value macroCall(MacroProcedure procedure, PairOrEmpty operands, Frame env);
 
-  /// Analagous to part of ContinuationProcedure.apply in Problem 21 (EC)
-  Expression continuationApply(
-      Continuation procedure, PairOrEmpty args, Frame env);
-
-  /// Analagous to MacroProcedure.eval_call in Problem 22 (EC)
-  Expression macroCall(
-      MacroProcedure procedure, PairOrEmpty operands, Frame env);
-
-  /// Analagous to do_define_macro in Problem 22
-  Expression doDefineMacro(PairOrEmpty expressions, Frame env);
+  /// Analagous to do_define_macro in Problem 21
+  Value doDefineMacro(PairOrEmpty expressions, Frame env);
 
   /// Async version of doDefineForm
-  Future<Expression> asyncDefineForm(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncDefineForm(PairOrEmpty expressions, Frame env);
 
   /// Async version of doAndForm
-  Future<Expression> asyncAndForm(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncAndForm(PairOrEmpty expressions, Frame env);
 
   /// Async version of doOrForm
-  Future<Expression> asyncOrForm(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncOrForm(PairOrEmpty expressions, Frame env);
 
   /// Async version of evalCondResult
-  Future<Expression> asyncCondResult(
-      PairOrEmpty clause, Frame env, Expression test);
+  Future<Value> asyncCondResult(PairOrEmpty clause, Frame env, Expression test);
 
   /// Async version of evalAll
-  Future<Expression> asyncEvalAll(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncEvalAll(PairOrEmpty expressions, Frame env);
 
   /// Async version of makeLetFrame
   Future<Frame> asyncLetFrame(PairOrEmpty bindings, Frame env);
 
   /// Async version of evalProcedureCall
-  Future<Expression> asyncEvalProcedureCall(
+  Future<Value> asyncEvalProcedureCall(
       Expression first, Expression rest, Frame env);
 
   /// Async version of procedureCall
-  Future<Expression> asyncProcedureCall(
+  Future<Value> asyncProcedureCall(
       Procedure procedure, PairOrEmpty operands, Frame env);
 
   /// Implements define-async. Similar to a regular procedure define.
-  Expression doDefineAsync(PairOrEmpty expressions, Frame env);
+  Value doDefineAsync(PairOrEmpty expressions, Frame env);
 
   /// Implements lambda-async. Similar to a regular lambda.
   LambdaProcedure doAsyncLambda(PairOrEmpty expressions, Frame env);
@@ -135,55 +126,42 @@ abstract class ProjectInterface {
 /// Use this as a mixin when not implementing tail call optimization
 /// If using this, make sure to set tailCallOptimization = true.
 abstract class UnimplementedTailCalls {
-  Expression tailEval(Expression expression, Frame env) {
+  Value tailEval(Expression expression, Frame env) {
     throw UnimplementedError("Tail calls not implemented");
-  }
-}
-
-/// Use this as a mixin when not implementing continuations
-abstract class UnimplementedContinuations {
-  Expression callWithCurrentContinuation(Procedure procedure, Frame env) {
-    throw UnimplementedError("Continuations not supported");
-  }
-
-  Expression continuationApply(
-      Continuation procedure, PairOrEmpty args, Frame env) {
-    throw UnimplementedError("Continuations not supported");
   }
 }
 
 /// Use this as a mixin when not implementing macros
 abstract class UnimplementedMacros {
-  Expression macroCall(
-      MacroProcedure procedure, PairOrEmpty operands, Frame env) {
+  Value macroCall(MacroProcedure procedure, PairOrEmpty operands, Frame env) {
     throw UnimplementedError("Macros not supported");
   }
 
-  Expression doDefineMacro(PairOrEmpty expressions, Frame env) {
+  Value doDefineMacro(PairOrEmpty expressions, Frame env) {
     throw UnimplementedError("Macros not supported");
   }
 }
 
 /// Use this as a mixin when not implementing the async-await.
 abstract class UnimplementedAsync {
-  Future<Expression> asyncDefineForm(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncDefineForm(PairOrEmpty expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Expression> asyncAndForm(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncAndForm(PairOrEmpty expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Expression> asyncOrForm(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncOrForm(PairOrEmpty expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Expression> asyncCondResult(
+  Future<Value> asyncCondResult(
       PairOrEmpty clause, Frame env, Expression test) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Expression> asyncEvalAll(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncEvalAll(PairOrEmpty expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
@@ -191,17 +169,17 @@ abstract class UnimplementedAsync {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Expression> asyncEvalProcedureCall(
+  Future<Value> asyncEvalProcedureCall(
       Expression first, Expression rest, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Expression> asyncProcedureCall(
+  Future<Value> asyncProcedureCall(
       Procedure procedure, PairOrEmpty operands, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Expression doDefineAsync(PairOrEmpty expressions, Frame env) {
+  Value doDefineAsync(PairOrEmpty expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 

--- a/lib/src/core/project_interface.dart
+++ b/lib/src/core/project_interface.dart
@@ -6,6 +6,7 @@ import 'expressions.dart';
 import 'frame.dart';
 import 'procedures.dart';
 import 'values.dart';
+import 'wrappers.dart';
 
 /// Interface for the Scheme project implementation.
 ///
@@ -36,77 +37,81 @@ abstract class ProjectInterface {
   Value lookupInFrame(SchemeSymbol symbol, Frame env);
 
   /// Analagous to BuiltinProcedure.apply in Problem 4
-  Value builtinApply(BuiltinProcedure procedure, PairOrEmpty args, Frame env);
+  Value builtinApply(BuiltinProcedure procedure, SchemeList args, Frame env);
 
   /// Analagous to part of scheme_eval implemented in Problem 5
   Value evalProcedureCall(Expression first, Expression rest, Frame env);
 
   /// Analagous to Procedure.eval_call in Problem 5
-  Value procedureCall(Procedure procedure, PairOrEmpty operands, Frame env);
+  Value procedureCall(
+      Procedure procedure, SchemeList<Expression> operands, Frame env);
 
   /// Analagous to do_define_form in Problems 6 and 10
-  Value doDefineForm(PairOrEmpty expressions, Frame env);
+  Value doDefineForm(SchemeList<Expression> expressions, Frame env);
 
   /// Analagous to do_quote_form in Problem 7
-  Value doQuoteForm(PairOrEmpty expressions, Frame env);
+  Value doQuoteForm(SchemeList<Expression> expressions, Frame env);
 
   /// Analagous to eval_all in Problem 8
-  Value evalAll(PairOrEmpty expressions, Frame env);
+  Value evalAll(SchemeList<Expression> expressions, Frame env);
 
   /// Analagous to do_lambda_form in Problem 9
-  LambdaProcedure doLambdaForm(PairOrEmpty expressions, Frame env);
+  LambdaProcedure doLambdaForm(SchemeList<Expression> expressions, Frame env);
 
   /// Analagous to Frame.make_child_frame in Problem 11
-  Frame makeChildOf(Expression formals, Expression vals, Frame parent);
+  Frame makeChildOf(Expression formals, SchemeList vals, Frame parent);
 
   /// Analagous to LambdaProcedure.make_call_frame in Problem 12
-  Frame makeLambdaFrame(LambdaProcedure procedure, PairOrEmpty args, Frame env);
+  Frame makeLambdaFrame(LambdaProcedure procedure, SchemeList args, Frame env);
 
   /// Analagous to do_and_form and do_or_form in Problem 13
-  Value doAndForm(PairOrEmpty expressions, Frame env);
-  Value doOrForm(PairOrEmpty expressions, Frame env);
+  Value doAndForm(SchemeList<Expression> expressions, Frame env);
+  Value doOrForm(SchemeList<Expression> expressions, Frame env);
 
   /// Analagous to part of do_cond_form in Problem 14
-  Value evalCondResult(PairOrEmpty clause, Frame env, Expression test);
+  Value evalCondResult(
+      SchemeList<Expression> clause, Frame env, Expression test);
 
   /// Analagous to make_let_frame in Problem 15
-  Frame makeLetFrame(PairOrEmpty bindings, Frame env);
+  Frame makeLetFrame(SchemeList<Expression> bindings, Frame env);
 
   /// Analagous to MuProcedure.make_call_frame in Problem 16
-  Frame makeMuFrame(MuProcedure procedure, PairOrEmpty args, Frame env);
+  Frame makeMuFrame(MuProcedure procedure, SchemeList args, Frame env);
 
   /// Analagous to do_mu_form in Problem 16
-  MuProcedure doMuForm(PairOrEmpty expressions, Frame env);
+  MuProcedure doMuForm(SchemeList<Expression> expressions, Frame env);
 
   /// Analagous to do_if_form, but with some changes from the spec
-  Value doIfForm(PairOrEmpty expressions, Frame env);
+  Value doIfForm(SchemeList<Expression> expressions, Frame env);
 
   /// Analagous to scheme_optimized_eval with tail=True in Problem 20 (EC)
   Value tailEval(Expression expression, Frame env);
 
   /// Analagous to MacroProcedure.eval_call in Problem 21 (EC)
-  Value macroCall(MacroProcedure procedure, PairOrEmpty operands, Frame env);
+  Value macroCall(
+      MacroProcedure procedure, SchemeList<Expression> operands, Frame env);
 
   /// Analagous to do_define_macro in Problem 21
-  Value doDefineMacro(PairOrEmpty expressions, Frame env);
+  Value doDefineMacro(SchemeList<Expression> expressions, Frame env);
 
   /// Async version of doDefineForm
-  Future<Value> asyncDefineForm(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncDefineForm(SchemeList<Expression> expressions, Frame env);
 
   /// Async version of doAndForm
-  Future<Value> asyncAndForm(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncAndForm(SchemeList<Expression> expressions, Frame env);
 
   /// Async version of doOrForm
-  Future<Value> asyncOrForm(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncOrForm(SchemeList<Expression> expressions, Frame env);
 
   /// Async version of evalCondResult
-  Future<Value> asyncCondResult(PairOrEmpty clause, Frame env, Expression test);
+  Future<Value> asyncCondResult(
+      SchemeList<Expression> clause, Frame env, Expression test);
 
   /// Async version of evalAll
-  Future<Value> asyncEvalAll(PairOrEmpty expressions, Frame env);
+  Future<Value> asyncEvalAll(SchemeList<Expression> expressions, Frame env);
 
   /// Async version of makeLetFrame
-  Future<Frame> asyncLetFrame(PairOrEmpty bindings, Frame env);
+  Future<Frame> asyncLetFrame(SchemeList<Expression> bindings, Frame env);
 
   /// Async version of evalProcedureCall
   Future<Value> asyncEvalProcedureCall(
@@ -114,13 +119,13 @@ abstract class ProjectInterface {
 
   /// Async version of procedureCall
   Future<Value> asyncProcedureCall(
-      Procedure procedure, PairOrEmpty operands, Frame env);
+      Procedure procedure, SchemeList<Expression> operands, Frame env);
 
   /// Implements define-async. Similar to a regular procedure define.
-  Value doDefineAsync(PairOrEmpty expressions, Frame env);
+  Value doDefineAsync(SchemeList<Expression> expressions, Frame env);
 
   /// Implements lambda-async. Similar to a regular lambda.
-  LambdaProcedure doAsyncLambda(PairOrEmpty expressions, Frame env);
+  LambdaProcedure doAsyncLambda(SchemeList<Expression> expressions, Frame env);
 }
 
 /// Use this as a mixin when not implementing tail call optimization
@@ -133,39 +138,40 @@ abstract class UnimplementedTailCalls {
 
 /// Use this as a mixin when not implementing macros
 abstract class UnimplementedMacros {
-  Value macroCall(MacroProcedure procedure, PairOrEmpty operands, Frame env) {
+  Value macroCall(
+      MacroProcedure procedure, SchemeList<Expression> operands, Frame env) {
     throw UnimplementedError("Macros not supported");
   }
 
-  Value doDefineMacro(PairOrEmpty expressions, Frame env) {
+  Value doDefineMacro(SchemeList<Expression> expressions, Frame env) {
     throw UnimplementedError("Macros not supported");
   }
 }
 
 /// Use this as a mixin when not implementing the async-await.
 abstract class UnimplementedAsync {
-  Future<Value> asyncDefineForm(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncDefineForm(SchemeList<Expression> expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Value> asyncAndForm(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncAndForm(SchemeList<Expression> expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Value> asyncOrForm(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncOrForm(SchemeList<Expression> expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
   Future<Value> asyncCondResult(
-      PairOrEmpty clause, Frame env, Expression test) {
+      SchemeList<Expression> clause, Frame env, Expression test) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Value> asyncEvalAll(PairOrEmpty expressions, Frame env) {
+  Future<Value> asyncEvalAll(SchemeList<Expression> expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Future<Frame> asyncLetFrame(PairOrEmpty bindings, Frame env) {
+  Future<Frame> asyncLetFrame(SchemeList<Expression> bindings, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
@@ -175,15 +181,15 @@ abstract class UnimplementedAsync {
   }
 
   Future<Value> asyncProcedureCall(
-      Procedure procedure, PairOrEmpty operands, Frame env) {
+      Procedure procedure, SchemeList<Expression> operands, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  Value doDefineAsync(PairOrEmpty expressions, Frame env) {
+  Value doDefineAsync(SchemeList<Expression> expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 
-  LambdaProcedure doAsyncLambda(PairOrEmpty expressions, Frame env) {
+  LambdaProcedure doAsyncLambda(SchemeList<Expression> expressions, Frame env) {
     throw UnimplementedError("Async/await not supported");
   }
 }

--- a/lib/src/core/scheme_library.dart
+++ b/lib/src/core/scheme_library.dart
@@ -1,6 +1,7 @@
 library cs61a_scheme.core.scheme_library;
 
 import 'expressions.dart';
+import 'frame.dart';
 
 /// An interface for defining a collection of built-in Scheme procedures.
 ///

--- a/lib/src/core/serialization.dart
+++ b/lib/src/core/serialization.dart
@@ -5,6 +5,7 @@ import 'dart:convert' show json;
 import 'expressions.dart';
 import 'logging.dart';
 import 'numbers.dart';
+import 'values.dart';
 
 final Map<String, Serializable> deserializers = {
   'Integer': Number.zero,
@@ -14,7 +15,7 @@ final Map<String, Serializable> deserializers = {
   'SchemeString': const SchemeString('x')
 };
 
-abstract class Serializable<T extends Expression> extends Expression {
+abstract class Serializable<T extends Value> extends Value {
   Map serialize();
   T deserialize(Map data);
 }
@@ -23,7 +24,7 @@ class Serialization {
   static String serializeToJson(Serializable expr) =>
       json.encode(expr.serialize());
 
-  static Expression deserialize(Map data) {
+  static Value deserialize(Map data) {
     if (!data.containsKey('type')) {
       throw SchemeException("Invalid serialized expression");
     } else if (!deserializers.containsKey(data['type'])) {
@@ -32,6 +33,6 @@ class Serialization {
     return deserializers[data['type']].deserialize(data);
   }
 
-  static Expression deserializeFromJson(String data) =>
+  static Value deserializeFromJson(String data) =>
       deserialize(json.decode(data));
 }

--- a/lib/src/core/special_forms.dart
+++ b/lib/src/core/special_forms.dart
@@ -1,23 +1,25 @@
 library cs61a_scheme.core.special_forms;
 
 import 'expressions.dart';
+import 'frame.dart';
 import 'logging.dart';
 import 'procedures.dart';
 import 'utils.dart' show checkForm, schemeEval;
+import 'values.dart';
 
-typedef SpecialForm = Expression Function(PairOrEmpty expressions, Frame env);
+typedef SpecialForm = Value Function(PairOrEmpty expressions, Frame env);
 
-Expression doDefineForm(PairOrEmpty expressions, Frame env) =>
+Value doDefineForm(PairOrEmpty expressions, Frame env) =>
     env.interpreter.impl.doDefineForm(expressions, env);
 
-Expression doIfForm(PairOrEmpty expressions, Frame env) =>
+Value doIfForm(PairOrEmpty expressions, Frame env) =>
     env.interpreter.impl.doIfForm(expressions, env);
 
-Expression doCondForm(PairOrEmpty expressions, Frame env) {
+Value doCondForm(PairOrEmpty expressions, Frame env) {
   while (!expressions.isNil) {
     Expression clause = expressions.pair.first;
     checkForm(clause, 1);
-    Expression test;
+    Value test;
     if (clause.pair.first == const SchemeSymbol('else')) {
       test = schemeTrue;
     } else {
@@ -31,24 +33,24 @@ Expression doCondForm(PairOrEmpty expressions, Frame env) {
   return undefined;
 }
 
-Expression doAndForm(PairOrEmpty expressions, Frame env) =>
+Value doAndForm(PairOrEmpty expressions, Frame env) =>
     env.interpreter.impl.doAndForm(expressions, env);
 
-Expression doOrForm(PairOrEmpty expressions, Frame env) =>
+Value doOrForm(PairOrEmpty expressions, Frame env) =>
     env.interpreter.impl.doOrForm(expressions, env);
 
-Expression doLetForm(PairOrEmpty expressions, Frame env) {
+Value doLetForm(PairOrEmpty expressions, Frame env) {
   checkForm(expressions, 2);
   Expression bindings = expressions.pair.first;
   Expression body = expressions.pair.second;
   Frame letEnv = env.interpreter.impl.makeLetFrame(bindings, env);
   env.interpreter.triggerEvent(const SchemeSymbol('new-frame'), [], letEnv);
-  Expression result = env.interpreter.impl.evalAll(body, letEnv);
+  Value result = env.interpreter.impl.evalAll(body, letEnv);
   env.interpreter.triggerEvent(const SchemeSymbol('return'), [result], letEnv);
   return result;
 }
 
-Expression doBeginForm(PairOrEmpty expressions, Frame env) {
+Value doBeginForm(PairOrEmpty expressions, Frame env) {
   checkForm(expressions, 1);
   return env.interpreter.impl.evalAll(expressions, env);
 }
@@ -67,16 +69,16 @@ Promise doDelayForm(PairOrEmpty expressions, Frame env) {
   return Promise(expressions.pair.first, env);
 }
 
-Pair<Expression, Promise> doConsStreamForm(PairOrEmpty expressions, Frame env) {
+Pair<Value, Promise> doConsStreamForm(PairOrEmpty expressions, Frame env) {
   checkForm(expressions, 2, 2);
   Promise promise = doDelayForm(expressions.pair.second, env);
   return Pair(schemeEval(expressions.pair.first, env), promise);
 }
 
-Expression doDefineMacroForm(PairOrEmpty expressions, Frame env) =>
+Value doDefineMacroForm(PairOrEmpty expressions, Frame env) =>
     env.interpreter.impl.doDefineMacro(expressions, env);
 
-Expression doSetForm(PairOrEmpty expressions, Frame env) {
+Undefined doSetForm(PairOrEmpty expressions, Frame env) {
   checkForm(expressions, 2, 2);
   Expression name = expressions.first;
   if (name is! SchemeSymbol) throw SchemeException("$name is not a symbol");

--- a/lib/src/core/special_forms.dart
+++ b/lib/src/core/special_forms.dart
@@ -6,43 +6,44 @@ import 'logging.dart';
 import 'procedures.dart';
 import 'utils.dart' show checkForm, schemeEval;
 import 'values.dart';
+import 'wrappers.dart';
 
-typedef SpecialForm = Value Function(PairOrEmpty expressions, Frame env);
+typedef SpecialForm = Value Function(
+    SchemeList<Expression> expressions, Frame env);
 
-Value doDefineForm(PairOrEmpty expressions, Frame env) =>
+Value doDefineForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doDefineForm(expressions, env);
 
-Value doIfForm(PairOrEmpty expressions, Frame env) =>
+Value doIfForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doIfForm(expressions, env);
 
-Value doCondForm(PairOrEmpty expressions, Frame env) {
-  while (!expressions.isNil) {
-    Expression clause = expressions.pair.first;
+Value doCondForm(SchemeList<Expression> expressions, Frame env) {
+  for (Expression clauseExpr in expressions) {
+    var clause = SchemeList<Expression>(clauseExpr);
     checkForm(clause, 1);
     Value test;
-    if (clause.pair.first == const SchemeSymbol('else')) {
+    if (clause.first == const SchemeSymbol('else')) {
       test = schemeTrue;
     } else {
-      test = schemeEval(clause.pair.first, env);
+      test = schemeEval(clause.first, env);
     }
     if (test.isTruthy) {
       return env.interpreter.impl.evalCondResult(clause, env, test);
     }
-    expressions = expressions.pair.second;
   }
   return undefined;
 }
 
-Value doAndForm(PairOrEmpty expressions, Frame env) =>
+Value doAndForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doAndForm(expressions, env);
 
-Value doOrForm(PairOrEmpty expressions, Frame env) =>
+Value doOrForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doOrForm(expressions, env);
 
-Value doLetForm(PairOrEmpty expressions, Frame env) {
+Value doLetForm(SchemeList<Expression> expressions, Frame env) {
   checkForm(expressions, 2);
-  Expression bindings = expressions.pair.first;
-  Expression body = expressions.pair.second;
+  var bindings = SchemeList<Expression>(expressions.first);
+  var body = expressions.rest;
   Frame letEnv = env.interpreter.impl.makeLetFrame(bindings, env);
   env.interpreter.triggerEvent(const SchemeSymbol('new-frame'), [], letEnv);
   Value result = env.interpreter.impl.evalAll(body, letEnv);
@@ -50,63 +51,63 @@ Value doLetForm(PairOrEmpty expressions, Frame env) {
   return result;
 }
 
-Value doBeginForm(PairOrEmpty expressions, Frame env) {
+Value doBeginForm(SchemeList<Expression> expressions, Frame env) {
   checkForm(expressions, 1);
   return env.interpreter.impl.evalAll(expressions, env);
 }
 
-LambdaProcedure doLambdaForm(PairOrEmpty expressions, Frame env) =>
+LambdaProcedure doLambdaForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doLambdaForm(expressions, env);
 
-MuProcedure doMuForm(PairOrEmpty expressions, Frame env) =>
+MuProcedure doMuForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doMuForm(expressions, env);
 
-Expression doQuoteForm(PairOrEmpty expressions, Frame env) =>
+Expression doQuoteForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doQuoteForm(expressions, env);
 
-Promise doDelayForm(PairOrEmpty expressions, Frame env) {
+Promise doDelayForm(SchemeList<Expression> expressions, Frame env) {
   checkForm(expressions, 1, 1);
-  return Promise(expressions.pair.first, env);
+  return Promise(expressions.first, env);
 }
 
-Pair<Value, Promise> doConsStreamForm(PairOrEmpty expressions, Frame env) {
+Pair<Value, Promise> doConsStreamForm(
+    SchemeList<Expression> expressions, Frame env) {
   checkForm(expressions, 2, 2);
-  Promise promise = doDelayForm(expressions.pair.second, env);
-  return Pair(schemeEval(expressions.pair.first, env), promise);
+  Promise promise = doDelayForm(expressions.rest, env);
+  return Pair(schemeEval(expressions.first, env), promise);
 }
 
-Value doDefineMacroForm(PairOrEmpty expressions, Frame env) =>
+Value doDefineMacroForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doDefineMacro(expressions, env);
 
-Undefined doSetForm(PairOrEmpty expressions, Frame env) {
+Undefined doSetForm(SchemeList<Expression> expressions, Frame env) {
   checkForm(expressions, 2, 2);
   Expression name = expressions.first;
   if (name is! SchemeSymbol) throw SchemeException("$name is not a symbol");
-  Expression value = schemeEval(expressions.elementAt(1), env);
+  Expression value = schemeEval(expressions.skip(1).first, env);
   env.update(name as SchemeSymbol, value);
   return undefined;
 }
 
-Expression doQuasiquoteForm(PairOrEmpty expressions, Frame env) {
+Value doQuasiquoteForm(SchemeList<Expression> expressions, Frame env) {
   checkForm(expressions, 1, 1);
   Expression expr = expressions.first;
-  Pair<Expression, Boolean> result = quasiquoteItem(expr, env);
+  Pair<Value, Boolean> result = quasiquoteItem(expr, env);
   if (result.second.isTruthy) {
     throw SchemeException("unquote-splicing not in list template: $expr");
   }
   return result.first;
 }
 
-Pair<Expression, Boolean> quasiquoteItem(Expression v, Frame env,
-    [int level = 1]) {
+Pair<Value, Boolean> quasiquoteItem(Value v, Frame env, [int level = 1]) {
   if (v is! Pair) return Pair(v, schemeFalse);
   Pair val = v.pair;
   bool splice = val.first == const SchemeSymbol('unquote-splicing');
   if (val.first == const SchemeSymbol('unquote') || splice) {
     if (--level == 0) {
-      Expression exprs = val.second;
+      SchemeList exprs = SchemeList(val.second);
       checkForm(exprs, 1, 1);
-      Expression eval = schemeEval(exprs.pair.first, env);
+      Value eval = schemeEval(exprs.first, env);
       if (splice && !(eval is PairOrEmpty && eval.wellFormed)) {
         throw SchemeException('unquote-splicing used on non-list $eval');
       }
@@ -115,10 +116,10 @@ Pair<Expression, Boolean> quasiquoteItem(Expression v, Frame env,
   } else if (val.first == const SchemeSymbol('quasiquote')) {
     level++;
   }
-  Pair<Expression, Boolean> result = quasiquoteItem(val.first, env, level);
-  Expression first = result.first;
+  Pair<Value, Boolean> result = quasiquoteItem(val.first, env, level);
+  Value first = result.first;
   splice = result.second.isTruthy;
-  Expression second = quasiquoteItem(val.second, env, level).first;
+  Value second = quasiquoteItem(val.second, env, level).first;
   if (splice) {
     if (!second.isNil) {
       return Pair(Pair.append([first, second]), schemeFalse);
@@ -128,6 +129,6 @@ Pair<Expression, Boolean> quasiquoteItem(Expression v, Frame env,
   return Pair(Pair(first, second), schemeFalse);
 }
 
-Expression doUnquoteForm(PairOrEmpty expressions, Frame env) {
+Value doUnquoteForm(SchemeList<Expression> expressions, Frame env) {
   throw SchemeException("Unquote outside of quasiquote");
 }

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -11,6 +11,7 @@ import 'procedures.dart';
 import 'scheme_library.dart';
 import 'utils.dart';
 import 'values.dart';
+import 'wrappers.dart';
 
 part 'standard_library.g.dart';
 
@@ -20,7 +21,7 @@ part 'standard_library.g.dart';
 @schemelib
 class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   /// Applies [procedure] to the given [args]
-  Value apply(Procedure procedure, PairOrEmpty args, Frame env) =>
+  Value apply(Procedure procedure, SchemeList args, Frame env) =>
       schemeApply(procedure, args, env);
 
   /// Displays [message] without a line break at the end
@@ -118,21 +119,21 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   num length(PairOrEmpty lst) => lst.lengthOrCycle;
 
   /// Constructs a list from zero or more arguments.
-  PairOrEmpty list(List<Value> args) => PairOrEmpty.fromIterable(args);
+  SchemeList list(List<Value> args) => SchemeList.fromIterable(args);
 
   /// Constructs a new list from calling [fn] on each item in [lst].
-  PairOrEmpty map(Procedure fn, PairOrEmpty lst, Frame env) =>
-      PairOrEmpty.fromIterable(
-          lst.map((item) => completeEval(fn.apply(Pair(item, nil), env))));
+  SchemeList map(Procedure fn, SchemeList lst, Frame env) =>
+      SchemeList.fromIterable(lst.map(
+          (item) => completeEval(fn.apply(SchemeList(Pair(item, nil)), env))));
 
   /// Constructs a new list of all items in [lst] that return true when passed
   /// to [pred].
-  PairOrEmpty filter(Procedure pred, PairOrEmpty lst, Frame env) =>
-      PairOrEmpty.fromIterable(lst.where(
-          (item) => completeEval(pred.apply(Pair(item, nil), env)).isTruthy));
+  SchemeList filter(Procedure pred, SchemeList lst, Frame env) =>
+      SchemeList.fromIterable(lst.where((item) =>
+          completeEval(pred.apply(SchemeList(Pair(item, nil)), env)).isTruthy));
 
   /// Reduces [lst] into a single expression by combining items with [combiner].
-  Expression reduce(Procedure combiner, PairOrEmpty lst, Frame env) =>
+  Value reduce(Procedure combiner, SchemeList lst, Frame env) =>
       lst.reduce((a, b) => combiner.apply(list([a, b]), env));
 
   /// Adds 0 or more numbers together.

--- a/lib/src/core/standard_library.g.dart
+++ b/lib/src/core/standard_library.g.dart
@@ -5,46 +5,46 @@ part of cs61a_scheme.core.standard_library;
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: unnecessary_lambdas
 abstract class _$StandardLibraryMixin {
-  Expression apply(Procedure procedure, PairOrEmpty args, Frame env);
-  void display(Expression message, Frame env);
-  Expression error(Expression message);
-  Expression errorNoTrace(Expression message);
-  Expression eval(Expression expr, Frame env);
-  Expression exit();
-  Expression load(Expression file, Frame env);
+  Value apply(Procedure procedure, PairOrEmpty args, Frame env);
+  void display(Value message, Frame env);
+  void error(Value message);
+  void errorNoTrace(Value message);
+  Value eval(Expression expr, Frame env);
+  void exit();
+  void load(Value file, Frame env);
   void newline(Frame env);
-  void print(Expression message, Frame env);
-  bool isAtom(Expression val);
-  bool isInteger(Expression val);
-  bool isList(Expression val);
-  bool isNumber(Expression val);
-  bool isNull(Expression val);
-  bool isPair(Expression val);
-  bool isProcedure(Expression val);
-  bool isPromise(Expression val);
-  bool isString(Expression val);
-  bool isSymbol(Expression val);
-  Expression append(List<Expression> args);
-  Expression car(Pair val);
-  Expression cdr(Pair val);
-  Pair cons(Expression car, Expression cdr);
+  void print(Value message, Frame env);
+  bool isAtom(Value val);
+  bool isInteger(Value val);
+  bool isList(Value val);
+  bool isNumber(Value val);
+  bool isNull(Value val);
+  bool isPair(Value val);
+  bool isProcedure(Value val);
+  bool isPromise(Value val);
+  bool isString(Value val);
+  bool isSymbol(Value val);
+  Value append(List<Value> args);
+  Value car(Pair val);
+  Value cdr(Pair val);
+  Pair cons(Value car, Value cdr);
   num length(PairOrEmpty lst);
-  PairOrEmpty list(List<Expression> args);
+  PairOrEmpty list(List<Value> args);
   PairOrEmpty map(Procedure fn, PairOrEmpty lst, Frame env);
   PairOrEmpty filter(Procedure pred, PairOrEmpty lst, Frame env);
   Expression reduce(Procedure combiner, PairOrEmpty lst, Frame env);
-  Number add(List<Expression> args);
-  Number sub(List<Expression> args);
-  Number mul(List<Expression> args);
-  Number truediv(List<Expression> args);
+  Number add(List<Number> nums);
+  Number sub(List<Number> nums);
+  Number mul(List<Number> nums);
+  Number truediv(List<Number> nums);
   Number abs(Number arg);
   Number expt(Number base, Number power);
   Number modulo(Number a, Number b);
   Number quotient(Number a, Number b);
   Number remainder(Number a, Number b);
-  bool isEq(Expression x, Expression y);
-  bool isEqual(Expression x, Expression y);
-  bool not(Expression arg);
+  bool isEq(Value x, Value y);
+  bool isEqual(Value x, Value y);
+  bool not(Value arg);
   bool eqNumbers(Number x, Number y);
   bool lt(Number x, Number y);
   bool gt(Number x, Number y);
@@ -55,9 +55,8 @@ abstract class _$StandardLibraryMixin {
   bool isZero(Number x);
   Expression force(Promise promise);
   Expression cdrStream(Pair stream);
-  void setCar(Pair pair, Expression val);
-  void setCdr(Pair pair, Expression val);
-  Expression callWithCurrentContinuation(Procedure procedure, Frame env);
+  void setCar(Pair pair, Value val);
+  void setCdr(Pair pair, Value val);
   String getRuntimeType(Expression expression);
   void importAll(Frame __env) {
     addBuiltin(__env, const SchemeSymbol("apply"), (__exprs, __env) {
@@ -66,7 +65,8 @@ abstract class _$StandardLibraryMixin {
       return this.apply(__exprs[0], __exprs[1], __env);
     }, 2,
         docs: Docs("apply", "Applies [procedure] to the given [args]\n",
-            [Param("procedure", "procedure"), Param(null, "args")]));
+            [Param("procedure", "procedure"), Param(null, "args")],
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("display"), (__exprs, __env) {
       this.display(__exprs[0], __env);
       return undefined;
@@ -74,30 +74,37 @@ abstract class _$StandardLibraryMixin {
         docs: Docs(
             "display",
             "Displays [message] without a line break at the end\n",
-            [Param(null, "message")]));
+            [Param("value", "message")]));
     addBuiltin(__env, const SchemeSymbol("error"), (__exprs, __env) {
-      return this.error(__exprs[0]);
+      this.error(__exprs[0]);
+      return undefined;
     }, 1,
         docs: Docs("error", "Raises an error with the given [message].\n",
-            [Param(null, "message")]));
+            [Param("value", "message")]));
     addBuiltin(__env, const SchemeSymbol('error-notrace'), (__exprs, __env) {
-      return this.errorNoTrace(__exprs[0]);
+      this.errorNoTrace(__exprs[0]);
+      return undefined;
     }, 1,
         docs: Docs(
             'error-notrace',
             "Raises an error with the given [message] and no traceback.\n",
-            [Param(null, "message")]));
+            [Param("value", "message")]));
     addBuiltin(__env, const SchemeSymbol("eval"), (__exprs, __env) {
+      if (__exprs[0] is! Expression)
+        throw SchemeException('Argument of invalid type passed to eval.');
       return this.eval(__exprs[0], __env);
     }, 1,
         docs: Docs("eval", "Evaluates [expr] in the current environment\n",
-            [Param(null, "expr")]));
+            [Param("expression", "expr")],
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("exit"), (__exprs, __env) {
-      return this.exit();
+      this.exit();
+      return undefined;
     }, 0,
         docs: Docs("exit", "Exits the interpreter (behavior may vary)\n", []));
     addBuiltin(__env, const SchemeSymbol("load"), (__exprs, __env) {
-      return this.load(__exprs[0], __env);
+      this.load(__exprs[0], __env);
+      return undefined;
     }, 1);
     addBuiltin(__env, const SchemeSymbol("newline"), (__exprs, __env) {
       this.newline(__env);
@@ -108,80 +115,82 @@ abstract class _$StandardLibraryMixin {
       return undefined;
     }, 1,
         docs: Docs("print", "Logs [message] to the interpreter.\n",
-            [Param(null, "message")]));
+            [Param("value", "message")]));
     addBuiltin(__env, const SchemeSymbol("atom?"), (__exprs, __env) {
       return Boolean(this.isAtom(__exprs[0]));
     }, 1,
         docs: Docs("atom?", "Returns true if [val] is an atomic expression.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("integer?"), (__exprs, __env) {
       return Boolean(this.isInteger(__exprs[0]));
     }, 1,
         docs: Docs("integer?", "Returns true if [val] is an integer.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("list?"), (__exprs, __env) {
       return Boolean(this.isList(__exprs[0]));
     }, 1,
         docs: Docs("list?", "Returns true if [val] is a well-formed list.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("number?"), (__exprs, __env) {
       return Boolean(this.isNumber(__exprs[0]));
     }, 1,
         docs: Docs("number?", "Returns true if [val] is an number.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("null?"), (__exprs, __env) {
       return Boolean(this.isNull(__exprs[0]));
     }, 1,
         docs: Docs("null?", "Returns true if [val] is the empty list.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("pair?"), (__exprs, __env) {
       return Boolean(this.isPair(__exprs[0]));
     }, 1,
-        docs: Docs(
-            "pair?", "Returns true if [val] is a pair.\n", [Param(null, "val")],
+        docs: Docs("pair?", "Returns true if [val] is a pair.\n",
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("procedure?"), (__exprs, __env) {
       return Boolean(this.isProcedure(__exprs[0]));
     }, 1,
         docs: Docs("procedure?", "Returns true if [val] is a procedure.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("promise?"), (__exprs, __env) {
       return Boolean(this.isPromise(__exprs[0]));
     }, 1,
         docs: Docs("promise?", "Returns true if [val] is a promise.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("string?"), (__exprs, __env) {
       return Boolean(this.isString(__exprs[0]));
     }, 1,
         docs: Docs("string?", "Returns true if [val] is a string.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("symbol?"), (__exprs, __env) {
       return Boolean(this.isSymbol(__exprs[0]));
     }, 1,
         docs: Docs("symbol?", "Returns true if [val] is a symbol.\n",
-            [Param(null, "val")],
+            [Param("value", "val")],
             returnType: "bool"));
     addVariableBuiltin(__env, const SchemeSymbol("append"), (__exprs, __env) {
       return this.append(__exprs);
     }, 0,
         maxArgs: -1,
         docs: Docs.variable("append",
-            "Appends zero or more lists together into a single list.\n"));
+            "Appends zero or more lists together into a single list.\n",
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("car"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to car.');
       return this.car(__exprs[0]);
     }, 1,
         docs: Docs(
-            "car", "Gets the first item in [val].\n", [Param("pair", "val")]));
+            "car", "Gets the first item in [val].\n", [Param("pair", "val")],
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("cdr"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to cdr.');
@@ -190,12 +199,13 @@ abstract class _$StandardLibraryMixin {
         docs: Docs(
             "cdr",
             "Gets the second item in [val] (typically the rest of a well-formed list).\n",
-            [Param("pair", "val")]));
+            [Param("pair", "val")],
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("cons"), (__exprs, __env) {
       return this.cons(__exprs[0], __exprs[1]);
     }, 2,
         docs: Docs("cons", "Constructs a pair from values [car] and [cdr].\n",
-            [Param(null, "car"), Param(null, "cdr")],
+            [Param("value", "car"), Param("value", "cdr")],
             returnType: "pair"));
     addBuiltin(__env, const SchemeSymbol("length"), (__exprs, __env) {
       if (__exprs[0] is! PairOrEmpty)
@@ -237,28 +247,37 @@ abstract class _$StandardLibraryMixin {
         docs: Docs(
             "reduce",
             "Reduces [lst] into a single expression by combining items with [combiner].\n",
-            [Param("procedure", "combiner"), Param(null, "lst")]));
+            [Param("procedure", "combiner"), Param(null, "lst")],
+            returnType: "expression"));
     addVariableBuiltin(__env, const SchemeSymbol("+"), (__exprs, __env) {
-      return this.add(__exprs);
+      if (__exprs.any((x) => x is! Number))
+        throw SchemeException('Argument of invalid type passed to +.');
+      return this.add(__exprs.cast<Number>());
     }, 0,
         maxArgs: -1,
         docs: Docs.variable("+", "Adds 0 or more numbers together.\n",
             returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("-"), (__exprs, __env) {
-      return this.sub(__exprs);
+      if (__exprs.any((x) => x is! Number))
+        throw SchemeException('Argument of invalid type passed to -.');
+      return this.sub(__exprs.cast<Number>());
     }, 1,
         maxArgs: -1,
         docs: Docs.variable("-",
             "If called with one number, negates it.\nOtherwise, subtracts the sum of all remaining arguments from the first.\n",
             returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("*"), (__exprs, __env) {
-      return this.mul(__exprs);
+      if (__exprs.any((x) => x is! Number))
+        throw SchemeException('Argument of invalid type passed to *.');
+      return this.mul(__exprs.cast<Number>());
     }, 0,
         maxArgs: -1,
         docs: Docs.variable("*", "Multiples 0 or more numbers together.\n",
             returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("/"), (__exprs, __env) {
-      return this.truediv(__exprs);
+      if (__exprs.any((x) => x is! Number))
+        throw SchemeException('Argument of invalid type passed to /.');
+      return this.truediv(__exprs.cast<Number>());
     }, 1,
         maxArgs: -1,
         docs: Docs.variable("/",
@@ -314,7 +333,7 @@ abstract class _$StandardLibraryMixin {
         docs: Docs(
             "eq?",
             "Determines if [x] and [y] are the same object.\n\nFor the purposes of this procedure, equivalent numbers, symbols, and\nstrings are considered the same object.\n",
-            [Param(null, "x"), Param(null, "y")],
+            [Param("value", "x"), Param("value", "y")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("equal?"), (__exprs, __env) {
       return Boolean(this.isEqual(__exprs[0], __exprs[1]));
@@ -322,13 +341,13 @@ abstract class _$StandardLibraryMixin {
         docs: Docs(
             "equal?",
             "Determines if [x] and [y] hold equivalent values.\n",
-            [Param(null, "x"), Param(null, "y")],
+            [Param("value", "x"), Param("value", "y")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("not"), (__exprs, __env) {
       return Boolean(this.not(__exprs[0]));
     }, 1,
-        docs: Docs(
-            "not", "Negates the truthiness of [arg].\n", [Param(null, "arg")],
+        docs: Docs("not", "Negates the truthiness of [arg].\n",
+            [Param("value", "arg")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("="), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Number)
@@ -401,7 +420,8 @@ abstract class _$StandardLibraryMixin {
       return this.force(__exprs[0]);
     }, 1,
         docs: Docs("force", "Forces [promise], evaluating it if necessary.\n",
-            [Param(null, "promise")]));
+            [Param(null, "promise")],
+            returnType: "expression"));
     addBuiltin(__env, const SchemeSymbol("cdr-stream"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to cdr-stream.');
@@ -410,7 +430,8 @@ abstract class _$StandardLibraryMixin {
         docs: Docs(
             "cdr-stream",
             "Finds the rest of [stream].\n\nEquivalent to (force (cdr [stream]))\n",
-            [Param("pair", "stream")]));
+            [Param("pair", "stream")],
+            returnType: "expression"));
     addBuiltin(__env, const SchemeSymbol("set-car!"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to set-car!.');
@@ -420,7 +441,7 @@ abstract class _$StandardLibraryMixin {
       return undefined;
     }, 2,
         docs: Docs("set-car!", "Mutates the car of [pair] to be [val].\n",
-            [Param("pair", "pair"), Param(null, "val")]));
+            [Param("pair", "pair"), Param("value", "val")]));
     addBuiltin(__env, const SchemeSymbol("set-cdr!"), (__exprs, __env) {
       if (__exprs[0] is! Pair)
         throw SchemeException('Argument of invalid type passed to set-cdr!.');
@@ -430,13 +451,11 @@ abstract class _$StandardLibraryMixin {
       return undefined;
     }, 2,
         docs: Docs("set-cdr!", "Mutates the cdr of [pair] to be [val].\n",
-            [Param("pair", "pair"), Param(null, "val")]));
-    addBuiltin(__env, const SchemeSymbol("call/cc"), (__exprs, __env) {
-      if (__exprs[0] is! Procedure)
-        throw SchemeException('Argument of invalid type passed to call/cc.');
-      return this.callWithCurrentContinuation(__exprs[0], __env);
-    }, 1);
+            [Param("pair", "pair"), Param("value", "val")]));
     addBuiltin(__env, const SchemeSymbol("runtime-type"), (__exprs, __env) {
+      if (__exprs[0] is! Expression)
+        throw SchemeException(
+            'Argument of invalid type passed to runtime-type.');
       return SchemeString(this.getRuntimeType(__exprs[0]));
     }, 1);
   }

--- a/lib/src/core/standard_library.g.dart
+++ b/lib/src/core/standard_library.g.dart
@@ -5,7 +5,7 @@ part of cs61a_scheme.core.standard_library;
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: unnecessary_lambdas
 abstract class _$StandardLibraryMixin {
-  Value apply(Procedure procedure, PairOrEmpty args, Frame env);
+  Value apply(Procedure procedure, SchemeList args, Frame env);
   void display(Value message, Frame env);
   void error(Value message);
   void errorNoTrace(Value message);
@@ -29,10 +29,10 @@ abstract class _$StandardLibraryMixin {
   Value cdr(Pair val);
   Pair cons(Value car, Value cdr);
   num length(PairOrEmpty lst);
-  PairOrEmpty list(List<Value> args);
-  PairOrEmpty map(Procedure fn, PairOrEmpty lst, Frame env);
-  PairOrEmpty filter(Procedure pred, PairOrEmpty lst, Frame env);
-  Expression reduce(Procedure combiner, PairOrEmpty lst, Frame env);
+  SchemeList list(List<Value> args);
+  SchemeList map(Procedure fn, SchemeList lst, Frame env);
+  SchemeList filter(Procedure pred, SchemeList lst, Frame env);
+  Value reduce(Procedure combiner, SchemeList lst, Frame env);
   Number add(List<Number> nums);
   Number sub(List<Number> nums);
   Number mul(List<Number> nums);
@@ -62,7 +62,7 @@ abstract class _$StandardLibraryMixin {
     addBuiltin(__env, const SchemeSymbol("apply"), (__exprs, __env) {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to apply.');
-      return this.apply(__exprs[0], __exprs[1], __env);
+      return this.apply(__exprs[0], SchemeList(__exprs[1]), __env);
     }, 2,
         docs: Docs("apply", "Applies [procedure] to the given [args]\n",
             [Param("procedure", "procedure"), Param(null, "args")],
@@ -216,7 +216,7 @@ abstract class _$StandardLibraryMixin {
             [Param(null, "lst")],
             returnType: "num"));
     addVariableBuiltin(__env, const SchemeSymbol("list"), (__exprs, __env) {
-      return this.list(__exprs);
+      return (this.list(__exprs)).list;
     }, 0,
         maxArgs: -1,
         docs: Docs.variable(
@@ -224,7 +224,7 @@ abstract class _$StandardLibraryMixin {
     addBuiltin(__env, const SchemeSymbol("map"), (__exprs, __env) {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to map.');
-      return this.map(__exprs[0], __exprs[1], __env);
+      return (this.map(__exprs[0], SchemeList(__exprs[1]), __env)).list;
     }, 2,
         docs: Docs(
             "map",
@@ -233,7 +233,7 @@ abstract class _$StandardLibraryMixin {
     addBuiltin(__env, const SchemeSymbol("filter"), (__exprs, __env) {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to filter.');
-      return this.filter(__exprs[0], __exprs[1], __env);
+      return (this.filter(__exprs[0], SchemeList(__exprs[1]), __env)).list;
     }, 2,
         docs: Docs(
             "filter",
@@ -242,13 +242,13 @@ abstract class _$StandardLibraryMixin {
     addBuiltin(__env, const SchemeSymbol("reduce"), (__exprs, __env) {
       if (__exprs[0] is! Procedure || __exprs[1] is! PairOrEmpty)
         throw SchemeException('Argument of invalid type passed to reduce.');
-      return this.reduce(__exprs[0], __exprs[1], __env);
+      return this.reduce(__exprs[0], SchemeList(__exprs[1]), __env);
     }, 2,
         docs: Docs(
             "reduce",
             "Reduces [lst] into a single expression by combining items with [combiner].\n",
             [Param("procedure", "combiner"), Param(null, "lst")],
-            returnType: "expression"));
+            returnType: "value"));
     addVariableBuiltin(__env, const SchemeSymbol("+"), (__exprs, __env) {
       if (__exprs.any((x) => x is! Number))
         throw SchemeException('Argument of invalid type passed to +.');

--- a/lib/src/core/utils.dart
+++ b/lib/src/core/utils.dart
@@ -9,19 +9,17 @@ import 'logging.dart';
 import 'procedures.dart';
 import 'reader.dart';
 import 'values.dart';
+import 'wrappers.dart';
 
-void checkForm(Expression expressions, int min, [int max = -1]) {
-  if (expressions is PairOrEmpty && expressions.wellFormed) {
-    int length = expressions.length;
-    if (length < min) {
-      throw SchemeException("$expressions must contain at least $min items.");
-    }
-    if (max > -1 && length > max) {
-      throw SchemeException("$expressions may contain at most $max items.");
-    }
-    return;
+void checkForm(SchemeList expressions, int min, [int max = -1]) {
+  int length = expressions.length;
+  if (length < min) {
+    throw SchemeException("$expressions must contain at least $min items.");
   }
-  throw SchemeException("$expressions is not a valid list.");
+  if (max > -1 && length > max) {
+    throw SchemeException("$expressions may contain at most $max items.");
+  }
+  return;
 }
 
 void checkFormals(Expression formals) {
@@ -51,7 +49,7 @@ Value schemeEval(Expression expr, Frame env) {
   }
 }
 
-Value schemeApply(Procedure procedure, PairOrEmpty args, Frame env) =>
+Value schemeApply(Procedure procedure, SchemeList args, Frame env) =>
     completeEval(procedure.apply(args, env));
 
 Value evalCallExpression(Pair expr, Frame env) {
@@ -62,7 +60,8 @@ Value evalCallExpression(Pair expr, Frame env) {
   Expression rest = expr.second;
   if (first is SchemeSymbol &&
       env.interpreter.specialForms.containsKey(first)) {
-    var result = env.interpreter.specialForms[first](rest, env);
+    var result =
+        env.interpreter.specialForms[first](SchemeList<Expression>(rest), env);
     env.interpreter.triggerEvent(first, [rest], env);
     return result;
   }

--- a/lib/src/core/utils.dart
+++ b/lib/src/core/utils.dart
@@ -4,9 +4,11 @@ import 'dart:async';
 
 import 'documentation.dart';
 import 'expressions.dart';
+import 'frame.dart';
 import 'logging.dart';
 import 'procedures.dart';
 import 'reader.dart';
+import 'values.dart';
 
 void checkForm(Expression expressions, int min, [int max = -1]) {
   if (expressions is PairOrEmpty && expressions.wellFormed) {
@@ -40,7 +42,7 @@ void checkFormals(Expression formals) {
   if (!formals.isNil) checkAndAdd(formals);
 }
 
-Expression schemeEval(Expression expr, Frame env) {
+Value schemeEval(Expression expr, Frame env) {
   try {
     return completeEval(expr.evaluate(env));
   } on SchemeException catch (e) {
@@ -49,10 +51,10 @@ Expression schemeEval(Expression expr, Frame env) {
   }
 }
 
-Expression schemeApply(Procedure procedure, PairOrEmpty args, Frame env) =>
+Value schemeApply(Procedure procedure, PairOrEmpty args, Frame env) =>
     completeEval(procedure.apply(args, env));
 
-Expression evalCallExpression(Pair expr, Frame env) {
+Value evalCallExpression(Pair expr, Frame env) {
   if (!expr.wellFormed) {
     throw SchemeException("Malformed list: $expr");
   }
@@ -69,7 +71,8 @@ Expression evalCallExpression(Pair expr, Frame env) {
   return env.interpreter.impl.evalProcedureCall(first, rest, env);
 }
 
-Expression completeEval(val) => val is Thunk ? val.evaluate(null) : val;
+Value completeEval(Value val) =>
+    val is Thunk ? schemeEval(val.expr, val.env) : val;
 
 addBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int args,
     {Docs docs}) {

--- a/lib/src/core/values.dart
+++ b/lib/src/core/values.dart
@@ -1,0 +1,130 @@
+library cs61a_scheme.core.values;
+
+import 'expressions.dart';
+import 'frame.dart';
+import 'logging.dart';
+import 'utils.dart';
+import 'widgets.dart';
+
+/// Base class for all Scheme data types.
+///
+/// Everything that can be touched by Scheme code should inherit from this.
+abstract class Value {
+  const Value();
+
+  /// All Scheme expressions are truthy except for the [Boolean] `#f`.
+  bool get isTruthy => true;
+
+  /// Determines how this expression is represented in environment diagrams.
+  ///
+  /// If true, this expression should be inlined in diagrams.
+  /// If false, it should be added to the objects with an arrow to it.
+  bool get inlineInDiagram => false;
+
+  /// Constructs a [Widget] for this value.
+  ///
+  /// The default implementation returns the string representation of this value
+  /// as a [TextWidget]. Some values may need to add objects to [diagram].
+  Widget draw(DiagramInterface diagram) => TextWidget(toString());
+
+  /// Shorthand for `expr is EmptyList`.
+  bool get isNil => false;
+
+  /// Defines how this expression should be displayed.
+  ///
+  /// Used by the `(display <expr>)` built-in. Defaults to [toString].
+  String get display => toString();
+
+  /// Should return a version of this object that can be passed to JS.
+  ///
+  /// The default implementation just returns the value itself, so this
+  /// should be overridden if passing to JS is intended.
+  dynamic toJS() => this;
+
+  /// Convenience function since casting as a Pair is very common.
+  Pair get pair => this as Pair;
+}
+
+/// Singleton class for [undefined].
+class Undefined extends Value {
+  const Undefined._internal();
+  toString() => "undefined";
+
+  /// If the web library has been loaded, this returns the JS value `undefined`.
+  ///
+  /// Otherwise, it returns null.
+  toJS() => Undefined.jsUndefined;
+
+  /// Initialized to the JS value `undefined` when the web library is loaded.
+  static dynamic jsUndefined;
+}
+
+/// Represents undefined values in Scheme, like `(if #f 1)`.
+const undefined = Undefined._internal();
+
+/// An expression to be evaluated in an environment.
+///
+/// Used internally for tail-call optimization. Should not be output.
+class Thunk extends Value {
+  final Expression expr;
+  final Frame env;
+  const Thunk(this.expr, this.env);
+  Expression evaluate(Frame _) {
+    List<Expression> expressions = [];
+    try {
+      Value result = this;
+      while (result is Thunk) {
+        Thunk thunk = result as Thunk;
+        expressions.insert(0, thunk.expr);
+        result = thunk.expr.evaluate(thunk.env);
+      }
+      return result;
+    } on SchemeException catch (e) {
+      expressions.forEach(e.addCall);
+      rethrow;
+    }
+  }
+
+  toJS() => throw StateError("Thunks should not be passed to JS");
+  toString() => 'Thunk($expr in f${env.id})';
+}
+
+/// A Scheme promise, used for Scheme streams.
+///
+/// A Scheme promise is a delayed expression that will be evaluated when forced.
+/// Once forced, the result is cached and returned directly when forced again.
+///
+/// Scheme promises are primarily used for created Scheme streams. A Scheme
+/// stream is the lazy equivalent of a Scheme list and is defined as a pair
+/// whose cdr is a promise that evaluates to another stream or the empty list.
+///
+/// It is semantically different from a JS Promise, which is equivalent to a
+/// Dart [Future]. The Scheme equivalent of [Future] is [AsyncExpression].
+///
+/// A Scheme stream is semantically different from a Dart Stream, which is an
+/// asynchronous sequence. A Scheme stream is analogous to a lazily-computed
+/// iterable built on a linked list.
+class Promise extends Value {
+  Expression expr;
+  final Frame env;
+  bool _evaluated = false;
+  Promise(this.expr, this.env);
+
+  /// Evaluates the promise, or returns the result if already evaluated.
+  Expression force() {
+    if (!_evaluated) {
+      expr = schemeEval(expr, env);
+      _evaluated = true;
+    }
+    return expr;
+  }
+
+  toString() => "#[promise (${_evaluated ? '' : 'not '}forced)]";
+
+  /// Promises are represented in diagrams as a circle with ⋯ inside prior to
+  /// forcing, and the evaluated result afterwards.
+  Widget draw(DiagramInterface diagram) {
+    var inside = _evaluated ? diagram.pointTo(expr) : TextWidget("⋯");
+    return Block.promise(inside);
+  }
+}

--- a/lib/src/core/widgets.dart
+++ b/lib/src/core/widgets.dart
@@ -5,11 +5,13 @@ library cs61a_scheme.core.widgets;
 import 'dart:async';
 
 import 'expressions.dart';
+import 'frame.dart';
 import 'logging.dart';
 import 'procedures.dart' show Procedure;
 import 'utils.dart' show schemeApply;
+import 'values.dart';
 
-class Direction extends SelfEvaluating {
+class Direction extends Value {
   final String _id;
 
   const Direction._(this._id);
@@ -53,9 +55,8 @@ class Direction extends SelfEvaluating {
 ///
 /// Whenever something extending [Widget] is logged, the web REPL will render it
 /// instead of just printing it. Used primarily for diagramming.
-abstract class Widget extends SelfEvaluating {
+abstract class Widget extends Value {
   Widget();
-  toJS() => this;
   final Map<Direction, Anchor> _anchors = {};
   Anchor anchor(Direction dir) => _anchors.putIfAbsent(dir, () => Anchor());
   Iterable<Direction> get anchoredDirections => _anchors.keys;
@@ -170,9 +171,9 @@ class BlockGrid extends Widget {
 abstract class DiagramInterface extends Widget {
   int get currentRow;
 
-  /// If expression.inlineInDiagram is true, returns expression.draw(this).
-  /// If not, returns an anchor that is linked to expression.draw(this).
+  /// If value.inlineInDiagram is true, returns value.draw(this).
+  /// If not, returns an anchor that is linked to value.draw(this).
   /// If parentRow is set, the new object will be on a new line, with spacing
   /// based on the parentRow.
-  Widget pointTo(Expression expression, [int parentRow]);
+  Widget pointTo(Value value, [int parentRow]);
 }

--- a/lib/src/core/widgets.dart
+++ b/lib/src/core/widgets.dart
@@ -10,6 +10,7 @@ import 'logging.dart';
 import 'procedures.dart' show Procedure;
 import 'utils.dart' show schemeApply;
 import 'values.dart';
+import 'wrappers.dart';
 
 class Direction extends Value {
   final String _id;
@@ -98,7 +99,7 @@ class MarkdownWidget extends TextWidget {
     if (env == null) return;
     var proc = env.lookup(SchemeSymbol.runtime(name));
     if (proc is Procedure) {
-      schemeApply(proc, nil, env);
+      schemeApply(proc, SchemeList(nil), env);
     }
   }
 }

--- a/lib/src/core/wrappers.dart
+++ b/lib/src/core/wrappers.dart
@@ -1,0 +1,66 @@
+library cs61a_scheme.core.wrappers;
+
+import 'dart:collection' show IterableBase;
+
+import 'expressions.dart';
+import 'logging.dart';
+import 'values.dart';
+
+class SchemeList<T extends Value> extends IterableBase<T> {
+  final PairOrEmpty _list;
+
+  SchemeList(this._list) {
+    if (!_list.wellFormed) {
+      throw SchemeException("$_list is not a Scheme list.");
+    }
+    if (T != Value) {
+      for (Value val in this) {
+        if (val is! T) throw SchemeException("Wrong type in Scheme list.");
+      }
+    }
+  }
+
+  SchemeList._noCheck(this._list);
+
+  factory SchemeList.fromValue(Value value) {
+    if (value is PairOrEmpty) return SchemeList<T>(value);
+    throw SchemeException('$value is not a Scheme list');
+  }
+
+  /// Creates a Scheme list from the given Dart iterable.
+  factory SchemeList.fromIterable(Iterable<T> iterable) {
+    PairOrEmpty result = nil;
+    for (T item in iterable.toList().reversed) {
+      result = Pair(item, result);
+    }
+    return SchemeList<T>._noCheck(result);
+  }
+
+  PairOrEmpty get list => _list;
+
+  SchemeList<T> get rest => isNotEmpty
+      ? SchemeList<T>._noCheck(_list.pair.second)
+      : throw SchemeException('No more items in list.');
+
+  Iterator<T> get iterator => _SchemeListIterator<T>(_list);
+
+  String toString() => list.toString();
+}
+
+class _SchemeListIterator<T extends Value> extends Iterator<T> {
+  T current;
+  Pair pair;
+  _SchemeListIterator(PairOrEmpty list) {
+    if (list is Pair) {
+      pair = list;
+    }
+  }
+  bool moveNext() {
+    if (pair != null) {
+      current = pair.first;
+      pair = pair.second is Pair ? pair.second : null;
+      return true;
+    }
+    return false;
+  }
+}

--- a/lib/src/extra/async.dart
+++ b/lib/src/extra/async.dart
@@ -41,7 +41,7 @@ class AsyncValue<T extends Value> extends Value {
 class AsyncLambdaProcedure extends LambdaProcedure {
   AsyncLambdaProcedure(formals, body, env) : super(formals, body, env);
 
-  AsyncValue apply(PairOrEmpty arguments, Frame env) {
+  AsyncValue apply(SchemeList arguments, Frame env) {
     Frame frame = makeCallFrame(arguments, env);
     FutureOr<Value> value = env.interpreter.impl.asyncEvalAll(body, frame);
     if (value is Value) return value;
@@ -60,22 +60,23 @@ class SchemeEventListener extends Value {
 }
 
 /// define-async special form
-Expression doDefineAsync(PairOrEmpty expressions, Frame env) =>
+Expression doDefineAsync(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doDefineAsync(expressions, env);
 
 /// lambda-async special form
-LambdaProcedure doAsyncLambda(PairOrEmpty expressions, Frame env) =>
+LambdaProcedure doAsyncLambda(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.doAsyncLambda(expressions, env);
 
 typedef AsyncSpecialForm = Future<Value> Function(
-    PairOrEmpty expressions, Frame env);
+    SchemeList<Expression> expressions, Frame env);
 
-FutureOr<Value> asyncEval(Expression exprs, Frame env) {
-  if (exprs is Pair) {
-    Expression first = exprs.first, rest = exprs.second;
+FutureOr<Value> asyncEval(Expression expr, Frame env) {
+  if (expr is Pair) {
+    var first = expr.first;
+    var rest = SchemeList<Expression>.fromValue(expr.second);
     if (first == const SchemeSymbol("await")) {
       checkForm(rest, 1, 1);
-      FutureOr<Value> result = asyncEval(rest.pair.first, env);
+      FutureOr<Value> result = asyncEval(rest.first, env);
       if (result is AsyncValue) {
         return result.future;
       } else if (result is Future<AsyncValue>) {
@@ -88,10 +89,11 @@ FutureOr<Value> asyncEval(Expression exprs, Frame env) {
     } else if (env.interpreter.specialForms.containsKey(first)) {
       return env.interpreter.specialForms[first](rest, env);
     } else {
-      return env.interpreter.impl.asyncEvalProcedureCall(first, rest, env);
+      return env.interpreter.impl
+          .asyncEvalProcedureCall(first, expr.second, env);
     }
   } else {
-    return schemeEval(exprs, env);
+    return schemeEval(expr, env);
   }
 }
 
@@ -110,10 +112,10 @@ Map<SchemeSymbol, AsyncSpecialForm> asyncSpecialForms = {
   const SchemeSymbol('unquote-splicing') : asyncUnquoteSplicingForm*/
 };
 
-Future<Value> asyncDefineForm(PairOrEmpty expressions, Frame env) =>
+Future<Value> asyncDefineForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.asyncDefineForm(expressions, env);
 
-Future<Value> asyncIfForm(PairOrEmpty expressions, Frame env) async {
+Future<Value> asyncIfForm(SchemeList<Expression> expressions, Frame env) async {
   checkForm(expressions, 2, 3);
   Expression predicate = expressions.first;
   if ((await asyncEval(predicate, env)).isTruthy) {
@@ -126,63 +128,64 @@ Future<Value> asyncIfForm(PairOrEmpty expressions, Frame env) async {
   return undefined;
 }
 
-Future<Value> asyncCondForm(PairOrEmpty expressions, Frame env) async {
-  while (!expressions.isNil) {
-    Expression clause = expressions.pair.first;
+Future<Value> asyncCondForm(
+    SchemeList<Expression> expressions, Frame env) async {
+  for (Expression clauseExpr in expressions) {
+    var clause = SchemeList<Expression>(clauseExpr);
     checkForm(clause, 1);
     Value test;
-    if ((clause.pair.first as SchemeSymbol).value == 'else') {
+    if ((clause.first as SchemeSymbol).value == 'else') {
       test = schemeTrue;
     } else {
-      test = await asyncEval(clause.pair.first, env);
+      test = await asyncEval(clause.first, env);
     }
     if (test.isTruthy) {
       return await env.interpreter.impl.asyncCondResult(clause, env, test);
     }
-    expressions = expressions.pair.second;
   }
   return undefined;
 }
 
-Future<Value> asyncAndForm(PairOrEmpty expressions, Frame env) =>
+Future<Value> asyncAndForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.asyncAndForm(expressions, env);
 
-Future<Value> asyncOrForm(PairOrEmpty expressions, Frame env) =>
+Future<Value> asyncOrForm(SchemeList<Expression> expressions, Frame env) =>
     env.interpreter.impl.asyncOrForm(expressions, env);
 
-Future<Value> asyncLetForm(PairOrEmpty expressions, Frame env) async {
+Future<Value> asyncLetForm(
+    SchemeList<Expression> expressions, Frame env) async {
   checkForm(expressions, 2);
-  Expression bindings = expressions.pair.first;
-  Expression body = expressions.pair.second;
+  var bindings = SchemeList<Expression>(expressions.first);
+  var body = expressions.rest;
   Frame letEnv = await env.interpreter.impl.asyncLetFrame(bindings, env);
   return await env.interpreter.impl.asyncEvalAll(body, letEnv);
 }
 
-Future<Value> asyncBeginForm(PairOrEmpty expressions, Frame env) async {
+Future<Value> asyncBeginForm(
+    SchemeList<Expression> expressions, Frame env) async {
   checkForm(expressions, 1);
   return await env.interpreter.impl.asyncEvalAll(expressions, env);
 }
 
 Future<Pair<Value, Promise>> asyncConsStreamForm(
-    PairOrEmpty expressions, Frame env) async {
+    SchemeList<Expression> expressions, Frame env) async {
   checkForm(expressions, 2, 2);
-  checkForm(expressions.pair.second, 1, 1);
-  Promise promise = Promise(expressions.pair.second, env);
-  return Pair(await asyncEval(expressions.pair.first, env), promise);
+  Promise promise = Promise(expressions.skip(1).first, env);
+  return Pair(await asyncEval(expressions.first, env), promise);
 }
 
-/*Expression doSetForm(PairOrEmpty expressions, Frame env) {
+/*Expression doSetForm(SchemeList<Expression> expressions, Frame env) {
   throw new UnimplementedError("Special form not yet implemented.");
 }
 
-Expression doQuasiquoteForm(PairOrEmpty expressions, Frame env) {
+Expression doQuasiquoteForm(SchemeList<Expression> expressions, Frame env) {
   throw new UnimplementedError("Special form not yet implemented.");
 }
 
-Expression doUnquoteForm(PairOrEmpty expressions, Frame env) {
+Expression doUnquoteForm(SchemeList<Expression> expressions, Frame env) {
   throw new UnimplementedError("Special form not yet implemented.");
 }
 
-Expression doUnquoteSplicingForm(PairOrEmpty expressions, Frame env) {
+Expression doUnquoteSplicingForm(SchemeList<Expression> expressions, Frame env){
   throw new UnimplementedError("Special form not yet implemented.");
 }*/

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -41,7 +41,7 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
         const SchemeSymbol("async:resolve"), resolver, 1);
     var reject =
         BuiltinProcedure.fixed(const SchemeSymbol("async:reject"), rejecter, 1);
-    var operands = PairOrEmpty.fromIterable([resolve, reject]);
+    var operands = SchemeList.fromIterable([resolve, reject]);
     Future.microtask(() => completeEval(proc.apply(operands, env)));
     return completer.future;
   }
@@ -49,7 +49,8 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   @SchemeSymbol("run-after")
   Future<Value> runAfter(Number millis, Procedure proc, Frame env) {
     var duration = Duration(milliseconds: millis.toJS());
-    return Future.delayed(duration, () => completeEval(proc.apply(nil, env)));
+    return Future.delayed(
+        duration, () => completeEval(proc.apply(SchemeList(nil), env)));
   }
 
   @SchemeSymbol("completed?")
@@ -68,8 +69,7 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
       Visualization(code, env);
 
   /// Returns a list of all bindings in the current environment.
-  PairOrEmpty bindings(Frame env) =>
-      PairOrEmpty.fromIterable(env.bindings.keys);
+  SchemeList bindings(Frame env) => SchemeList.fromIterable(env.bindings.keys);
 
   /// Triggers an event with a given name (first arg) and arguments.
   @SchemeSymbol('trigger-event')
@@ -86,13 +86,13 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   SchemeEventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env) {
     var callback = (exprs, env) {
       try {
-        schemeApply(onEvent, PairOrEmpty.fromIterable(exprs), env);
+        schemeApply(onEvent, SchemeList.fromIterable(exprs), env);
         // ignore: avoid_catches_without_on_clauses
       } catch (e) {
         if (e is SchemeException) {
           e.addCall(onEvent);
-          var eventPair = Pair(id, PairOrEmpty.fromIterable(exprs));
-          e.addCall(TextMessage('<event $eventPair>'));
+          var eventList = SchemeList.fromIterable([id] + exprs);
+          e.addCall(TextMessage('<event $eventList>'));
         }
         env.interpreter.logError(e);
       }

--- a/lib/src/extra/extra_library.dart
+++ b/lib/src/extra/extra_library.dart
@@ -26,8 +26,8 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   }
 
   @SchemeSymbol("run-async")
-  Future<Expression> runAsync(Procedure proc, Frame env) {
-    var completer = Completer<Expression>();
+  Future<Value> runAsync(Procedure proc, Frame env) {
+    var completer = Completer<Value>();
 
     var resolver = (args, env) {
       completer.complete(args[0]);
@@ -47,17 +47,17 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   }
 
   @SchemeSymbol("run-after")
-  Future<Expression> runAfter(Number millis, Procedure proc, Frame env) {
+  Future<Value> runAfter(Number millis, Procedure proc, Frame env) {
     var duration = Duration(milliseconds: millis.toJS());
     return Future.delayed(duration, () => completeEval(proc.apply(nil, env)));
   }
 
   @SchemeSymbol("completed?")
-  Boolean isCompleted(AsyncExpression expr) =>
+  Boolean isCompleted(AsyncValue expr) =>
       expr.complete ? schemeTrue : schemeFalse;
 
-  /// Creates a diagram of [expression].
-  Diagram draw(Expression expression) => Diagram(expression);
+  /// Creates a diagram of [value].
+  Diagram draw(Value value) => Diagram(value);
 
   /// Create a diagram of the current environment.
   Diagram diagram(Frame env) => Diagram(env);
@@ -74,11 +74,11 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
   /// Triggers an event with a given name (first arg) and arguments.
   @SchemeSymbol('trigger-event')
   @MinArgs(1)
-  void triggerEvent(List<Expression> exprs, Frame env) {
-    if (exprs.first is! SchemeSymbol) {
-      throw SchemeException('${exprs.first} is not a symbol');
+  void triggerEvent(List<Value> args, Frame env) {
+    if (args.first is! SchemeSymbol) {
+      throw SchemeException('${args.first} is not a symbol');
     }
-    env.interpreter.triggerEvent(exprs[0], exprs.skip(1).toList(), env);
+    env.interpreter.triggerEvent(args[0], args.skip(1).toList(), env);
   }
 
   /// Sets up an listener to call [onEvent] when an event with [id] occurs.
@@ -113,10 +113,10 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
     env.interpreter.stopAllListeners(id);
   }
 
-  /// Constructs a string from the display values of any number of expressions.
+  /// Constructs a string from the display values of any number of values.
   @SchemeSymbol('string-append')
-  String stringAppend(List<Expression> exprs) =>
-      exprs.map((e) => e.display).join('');
+  String stringAppend(List<Value> values) =>
+      values.map((e) => e.display).join('');
 
   String serialize(Serializable expr) => Serialization.serializeToJson(expr);
 
@@ -124,8 +124,8 @@ class ExtraLibrary extends SchemeLibrary with _$ExtraLibraryMixin {
       Serialization.deserializeFromJson(json);
 
   /// Renders all provided text as a block of Markdown.
-  MarkdownWidget formatted(List<Expression> expressions, Frame env) {
-    String text = expressions.map((expr) => expr.display).join('');
+  MarkdownWidget formatted(List<Value> values, Frame env) {
+    String text = values.map((expr) => expr.display).join('');
     return MarkdownWidget(text, inline: true, env: env);
   }
 

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -5,21 +5,21 @@ part of cs61a_scheme.extra.extra_library;
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: unnecessary_lambdas
 abstract class _$ExtraLibraryMixin {
-  Future<Expression> runAsync(Procedure proc, Frame env);
-  Future<Expression> runAfter(Number millis, Procedure proc, Frame env);
-  Boolean isCompleted(AsyncExpression expr);
-  Diagram draw(Expression expression);
+  Future<Value> runAsync(Procedure proc, Frame env);
+  Future<Value> runAfter(Number millis, Procedure proc, Frame env);
+  Boolean isCompleted(AsyncValue expr);
+  Diagram draw(Value value);
   Diagram diagram(Frame env);
   Visualization visualize(List<Expression> code, Frame env);
   PairOrEmpty bindings(Frame env);
-  void triggerEvent(List<Expression> exprs, Frame env);
+  void triggerEvent(List<Value> args, Frame env);
   SchemeEventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env);
   void cancelListener(SchemeEventListener listener, Frame env);
   void cancelAll(SchemeSymbol id, Frame env);
-  String stringAppend(List<Expression> exprs);
+  String stringAppend(List<Value> values);
   String serialize(Serializable expr);
   Expression deserialize(String json);
-  MarkdownWidget formatted(List<Expression> expressions, Frame env);
+  MarkdownWidget formatted(List<Value> values, Frame env);
   void logicStart(Frame env);
   Docs docs(SchemeSymbol topic, Frame env);
   void allDocs(Frame env);
@@ -27,30 +27,34 @@ abstract class _$ExtraLibraryMixin {
     addBuiltin(__env, const SchemeSymbol("run-async"), (__exprs, __env) {
       if (__exprs[0] is! Procedure)
         throw SchemeException('Argument of invalid type passed to run-async.');
-      return AsyncExpression(this.runAsync(__exprs[0], __env));
+      return AsyncValue(this.runAsync(__exprs[0], __env));
     }, 1);
     addBuiltin(__env, const SchemeSymbol("run-after"), (__exprs, __env) {
       if (__exprs[0] is! Number || __exprs[1] is! Procedure)
         throw SchemeException('Argument of invalid type passed to run-after.');
-      return AsyncExpression(this.runAfter(__exprs[0], __exprs[1], __env));
+      return AsyncValue(this.runAfter(__exprs[0], __exprs[1], __env));
     }, 2);
     addBuiltin(__env, const SchemeSymbol("completed?"), (__exprs, __env) {
-      if (__exprs[0] is! AsyncExpression)
+      if (__exprs[0] is! AsyncValue)
         throw SchemeException('Argument of invalid type passed to completed?.');
       return this.isCompleted(__exprs[0]);
     }, 1);
     addBuiltin(__env, const SchemeSymbol("draw"), (__exprs, __env) {
       return this.draw(__exprs[0]);
     }, 1,
-        docs: Docs("draw", "Creates a diagram of [expression].\n",
-            [Param(null, "expression")]));
+        docs: Docs("draw", "Creates a diagram of [value].\n",
+            [Param("value", "value")]));
     addBuiltin(__env, const SchemeSymbol("diagram"), (__exprs, __env) {
       return this.diagram(__env);
     }, 0,
         docs: Docs(
             "diagram", "Create a diagram of the current environment.\n", []));
-    addVariableOperandBuiltin(
-        __env, const SchemeSymbol("visualize"), this.visualize, 0,
+    addVariableOperandBuiltin(__env, const SchemeSymbol("visualize"),
+        (__exprs, __env) {
+      if (__exprs.any((x) => x is! Expression))
+        throw SchemeException('Argument of invalid type passed to visualize.');
+      return this.visualize(__exprs.cast<Expression>(), __env);
+    }, 0,
         maxArgs: -1,
         docs: Docs.variable(
             "visualize", "Visualizes the execution of a piece of code.\n"));
@@ -104,7 +108,7 @@ abstract class _$ExtraLibraryMixin {
     }, 0,
         maxArgs: -1,
         docs: Docs.variable('string-append',
-            "Constructs a string from the display values of any number of expressions.\n",
+            "Constructs a string from the display values of any number of values.\n",
             returnType: "string"));
     addBuiltin(__env, const SchemeSymbol("serialize"), (__exprs, __env) {
       if (__exprs[0] is! Serializable)

--- a/lib/src/extra/extra_library.g.dart
+++ b/lib/src/extra/extra_library.g.dart
@@ -11,7 +11,7 @@ abstract class _$ExtraLibraryMixin {
   Diagram draw(Value value);
   Diagram diagram(Frame env);
   Visualization visualize(List<Expression> code, Frame env);
-  PairOrEmpty bindings(Frame env);
+  SchemeList bindings(Frame env);
   void triggerEvent(List<Value> args, Frame env);
   SchemeEventListener listenFor(SchemeSymbol id, Procedure onEvent, Frame env);
   void cancelListener(SchemeEventListener listener, Frame env);
@@ -59,7 +59,7 @@ abstract class _$ExtraLibraryMixin {
         docs: Docs.variable(
             "visualize", "Visualizes the execution of a piece of code.\n"));
     addBuiltin(__env, const SchemeSymbol("bindings"), (__exprs, __env) {
-      return this.bindings(__env);
+      return (this.bindings(__env)).list;
     }, 0,
         docs: Docs(
             "bindings",

--- a/lib/src/extra/logic_library.g.dart
+++ b/lib/src/extra/logic_library.g.dart
@@ -12,7 +12,9 @@ abstract class _$LogicLibraryMixin {
   void importAll(Frame __env) {
     addVariableOperandBuiltin(__env, const SchemeSymbol('fact'),
         (__exprs, __env) {
-      this.fact(__exprs);
+      if (__exprs.any((x) => x is! Expression))
+        throw SchemeException('Argument of invalid type passed to fact.');
+      this.fact(__exprs.cast<Expression>());
       return undefined;
     }, 0,
         maxArgs: -1,
@@ -23,7 +25,9 @@ abstract class _$LogicLibraryMixin {
     __env.hidden[const SchemeSymbol('!')] = true;
     addVariableOperandBuiltin(__env, const SchemeSymbol('query'),
         (__exprs, __env) {
-      this.query(__exprs, __env);
+      if (__exprs.any((x) => x is! Expression))
+        throw SchemeException('Argument of invalid type passed to query.');
+      this.query(__exprs.cast<Expression>(), __env);
       return undefined;
     }, 0,
         maxArgs: -1,
@@ -34,7 +38,9 @@ abstract class _$LogicLibraryMixin {
     __env.hidden[const SchemeSymbol('?')] = true;
     addVariableOperandBuiltin(__env, const SchemeSymbol('query-one'),
         (__exprs, __env) {
-      this.queryOne(__exprs, __env);
+      if (__exprs.any((x) => x is! Expression))
+        throw SchemeException('Argument of invalid type passed to query-one.');
+      this.queryOne(__exprs.cast<Expression>(), __env);
       return undefined;
     }, 0,
         maxArgs: -1,

--- a/lib/src/extra/operand_procedures.dart
+++ b/lib/src/extra/operand_procedures.dart
@@ -11,7 +11,7 @@ class OperandBuiltinProcedure extends BuiltinProcedure {
       : super.variable(name, fn, minArgs, maxArgs);
 
   @override
-  Expression call(PairOrEmpty operands, Frame env) => apply(operands, env);
+  Value call(PairOrEmpty operands, Frame env) => apply(operands, env);
 }
 
 addOperandBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int args,

--- a/lib/src/extra/operand_procedures.dart
+++ b/lib/src/extra/operand_procedures.dart
@@ -11,7 +11,8 @@ class OperandBuiltinProcedure extends BuiltinProcedure {
       : super.variable(name, fn, minArgs, maxArgs);
 
   @override
-  Value call(PairOrEmpty operands, Frame env) => apply(operands, env);
+  Value call(SchemeList<Expression> operands, Frame env) =>
+      apply(operands, env);
 }
 
 addOperandBuiltin(Frame env, SchemeSymbol name, SchemeBuiltin fn, int args,

--- a/lib/src/extra/theming.dart
+++ b/lib/src/extra/theming.dart
@@ -2,7 +2,7 @@ library cs61a_scheme.extra.theming;
 
 import 'package:cs61a_scheme/cs61a_scheme.dart';
 
-class Theme extends SelfEvaluating implements Serializable<Theme> {
+class Theme extends Value implements Serializable<Theme> {
   Map<SchemeSymbol, Color> colors = {};
   Map<SchemeSymbol, SchemeString> cssProps = {};
 
@@ -66,7 +66,7 @@ class Theme extends SelfEvaluating implements Serializable<Theme> {
   }
 }
 
-class Color extends SelfEvaluating implements Serializable<Color> {
+class Color extends Value implements Serializable<Color> {
   final int red, green, blue;
   final double alpha;
 

--- a/lib/src/web/imports.dart
+++ b/lib/src/web/imports.dart
@@ -5,7 +5,7 @@ import 'dart:html' as html;
 
 import 'package:cs61a_scheme/cs61a_scheme_extra.dart';
 
-class ImportedLibrary extends SelfEvaluating {
+class ImportedLibrary extends Value {
   Frame env;
   String code;
 
@@ -17,8 +17,8 @@ class ImportedLibrary extends SelfEvaluating {
     List<Expression> tokens = tokenizeLines(code.split('\n')).toList();
     while (tokens.isNotEmpty) {
       Expression expr = schemeRead(tokens, env.interpreter.impl);
-      Expression result = schemeEval(expr, env);
-      if (result is AsyncExpression) {
+      Value result = schemeEval(expr, env);
+      if (result is AsyncValue) {
         await result.future;
       }
     }

--- a/lib/src/web/js_interop.dart
+++ b/lib/src/web/js_interop.dart
@@ -17,9 +17,9 @@ class JsProcedure extends Procedure {
   toJS() => fn;
 }
 
-class JsExpression extends SelfEvaluating {
+class JsValue extends Value {
   final JsObject obj;
-  JsExpression(this.obj);
+  JsValue(this.obj);
   toString() {
     var objString = obj.toString();
     if (objString.length > 20) objString = objString.substring(0, 17) + "...";
@@ -29,9 +29,9 @@ class JsExpression extends SelfEvaluating {
   toJS() => obj;
 }
 
-class NativeExpression extends SelfEvaluating {
+class NativeValue extends Value {
   final Object obj;
-  NativeExpression(this.obj);
+  NativeValue(this.obj);
   toString() {
     var objString = obj.toString();
     if (objString.length > 20) objString = objString.substring(0, 17) + "...";
@@ -41,7 +41,7 @@ class NativeExpression extends SelfEvaluating {
   toJS() => obj;
 }
 
-Expression jsToScheme(obj) {
+Value jsToScheme(obj) {
   if (obj is Expression) return obj;
   if (obj is num) return Number.fromNum(obj);
   if (obj is bool) return obj ? schemeTrue : schemeFalse;
@@ -51,19 +51,19 @@ Expression jsToScheme(obj) {
   if (obj is JsObject) return jsObjectToScheme(obj);
   if (obj == null) return undefined;
   if (obj == context['undefined']) return undefined;
-  return NativeExpression(obj);
+  return NativeValue(obj);
 }
 
-Expression jsObjectToScheme(JsObject obj) {
+Value jsObjectToScheme(JsObject obj) {
   var type =
       context['Object']['prototype']['toString'].callMethod('call', [obj]);
   if (type == '[object Promise]') {
     var completer = Completer();
     obj.callMethod('then', [completer.complete, completer.completeError]);
     var future = completer.future.then(jsToScheme);
-    return AsyncExpression(future)..jsPromise = obj;
+    return AsyncValue(future)..jsPromise = obj;
   }
-  return JsExpression(obj);
+  return JsValue(obj);
 }
 
 Expression jsEval(String code) {

--- a/lib/src/web/js_interop.dart
+++ b/lib/src/web/js_interop.dart
@@ -9,7 +9,7 @@ class JsProcedure extends Procedure {
   final SchemeSymbol name = null;
   final JsFunction fn;
   JsProcedure(this.fn);
-  Expression apply(PairOrEmpty args, Frame env) {
+  Expression apply(SchemeList args, Frame env) {
     var result = fn.apply(args.map((arg) => arg.toJS()).toList());
     return jsToScheme(result);
   }
@@ -80,11 +80,11 @@ class SchemeFunction {
   Procedure procedure;
   Frame env;
   SchemeFunction(this.procedure, this.env);
-  call() => schemeApply(procedure, nil, null).toJS();
+  call() => schemeApply(procedure, SchemeList(nil), null).toJS();
   noSuchMethod(Invocation invocation) {
     if (invocation.memberName == const Symbol("call")) {
       var args = invocation.positionalArguments.map(jsToScheme);
-      return schemeApply(procedure, PairOrEmpty.fromIterable(args), env).toJS();
+      return schemeApply(procedure, SchemeList.fromIterable(args), env).toJS();
     }
     throw SchemeException(
         "Something has gone horribly wrong with wrapped procedures");

--- a/lib/src/web/turtle_library.g.dart
+++ b/lib/src/web/turtle_library.g.dart
@@ -90,8 +90,10 @@ abstract class _$TurtleLibraryMixin {
         __env.bindings[const SchemeSymbol('right')];
     __env.hidden[const SchemeSymbol('rt')] = true;
     addVariableBuiltin(__env, const SchemeSymbol("circle"), (__exprs, __env) {
+      if (__exprs.any((x) => x is! Expression))
+        throw SchemeException('Argument of invalid type passed to circle.');
       turtle.show();
-      this.circle(__exprs);
+      this.circle(__exprs.cast<Expression>());
       return undefined;
     }, 1,
         maxArgs: 2,
@@ -151,12 +153,14 @@ abstract class _$TurtleLibraryMixin {
       return undefined;
     }, 0, docs: Docs('turtle-clear', "Clears the current turtle state.\n", []));
     addBuiltin(__env, const SchemeSymbol("color"), (__exprs, __env) {
+      if (__exprs[0] is! Expression)
+        throw SchemeException('Argument of invalid type passed to color.');
       turtle.show();
       this.color(__exprs[0]);
       return undefined;
     }, 1,
         docs: Docs("color", "Sets the pen color of the turtle.\n",
-            [Param(null, "color")]));
+            [Param("expression", "color")]));
     addBuiltin(__env, const SchemeSymbol('begin_fill'), (__exprs, __env) {
       turtle.show();
       this.beginFill();
@@ -190,6 +194,8 @@ abstract class _$TurtleLibraryMixin {
         docs: Docs('turtle-exit',
             "Closes the turtle canvas, reseting its state.\n", []));
     addBuiltin(__env, const SchemeSymbol("bgcolor"), (__exprs, __env) {
+      if (__exprs[0] is! Expression)
+        throw SchemeException('Argument of invalid type passed to bgcolor.');
       turtle.show();
       this.bgcolor(__exprs[0]);
       return undefined;
@@ -197,7 +203,7 @@ abstract class _$TurtleLibraryMixin {
         docs: Docs(
             "bgcolor",
             "Sets the background color of the turtle canvas.\n",
-            [Param(null, "color")]));
+            [Param("expression", "color")]));
     addBuiltin(__env, const SchemeSymbol("pensize"), (__exprs, __env) {
       if (__exprs[0] is! Number)
         throw SchemeException('Argument of invalid type passed to pensize.');
@@ -238,7 +244,9 @@ abstract class _$TurtleLibraryMixin {
             "Sets the exterior dimensions of the turtle's canvas.\n\nThis does not effect the current state of the turtle.\n",
             [Param("int", "width"), Param("int", "height")]));
     addBuiltin(__env, const SchemeSymbol("pixel"), (__exprs, __env) {
-      if (__exprs[0] is! Number || __exprs[1] is! Number)
+      if (__exprs[0] is! Number ||
+          __exprs[1] is! Number ||
+          __exprs[2] is! Expression)
         throw SchemeException('Argument of invalid type passed to pixel.');
       turtle.show();
       this.pixel(__exprs[0].toJS(), __exprs[1].toJS(), __exprs[2]);
@@ -247,7 +255,11 @@ abstract class _$TurtleLibraryMixin {
         docs: Docs(
             "pixel",
             "Draws a box with [color] in the turtle's current pixel size at ([x], [y])\n",
-            [Param("num", "x"), Param("num", "y"), Param(null, "color")]));
+            [
+              Param("num", "x"),
+              Param("num", "y"),
+              Param("expression", "color")
+            ]));
     addBuiltin(__env, const SchemeSymbol("pixelsize"), (__exprs, __env) {
       if (__exprs[0] is! Integer)
         throw SchemeException('Argument of invalid type passed to pixelsize.');
@@ -280,7 +292,10 @@ abstract class _$TurtleLibraryMixin {
     __env.hidden[const SchemeSymbol('screen-height')] = true;
     addVariableBuiltin(__env, const SchemeSymbol('unsupported'),
         (__exprs, __env) {
-      this.unsupported(__exprs, __env);
+      if (__exprs.any((x) => x is! Expression))
+        throw SchemeException(
+            'Argument of invalid type passed to unsupported.');
+      this.unsupported(__exprs.cast<Expression>(), __env);
       return undefined;
     }, 0,
         maxArgs: -1,

--- a/lib/src/web/web_library.g.dart
+++ b/lib/src/web/web_library.g.dart
@@ -5,25 +5,25 @@ part of cs61a_scheme.web.web_library;
 // ignore_for_file: prefer_expression_function_bodies
 // ignore_for_file: unnecessary_lambdas
 abstract class _$WebLibraryMixin {
-  Expression js(List<Expression> exprs);
-  JsExpression jsContext();
-  Expression jsSet(JsExpression obj, Expression property, Expression value);
-  Expression jsRef(JsExpression obj, Expression property);
-  Expression jsCall(List<Expression> expressions);
-  Expression jsObject(List<Expression> expressions);
-  bool isJsObject(Expression expression);
-  bool isJsProcedure(Expression expression);
+  Value js(List<Value> exprs);
+  JsValue jsContext();
+  Value jsSet(JsValue obj, Value property, Value value);
+  Value jsRef(JsValue obj, Value property);
+  Value jsCall(List<Value> vals);
+  Value jsObject(List<Value> vals);
+  bool isJsObject(Value value);
+  bool isJsProcedure(Value value);
   Color rgb(int r, int g, int b);
   Color rgba(int r, int g, int b, num a);
   Color hex(String hex);
   Theme makeTheme();
-  void themeSetColor(Theme theme, SchemeSymbol property, Expression color);
+  void themeSetColor(Theme theme, SchemeSymbol property, Value color);
   void themeSetCss(Theme theme, SchemeSymbol property, SchemeString code);
   void applyThemeBuiltin(Theme theme);
-  Future<Expression> schemeImport(List<Expression> args, Frame env);
-  Future<Expression> schemeImportInline(Expression id, Frame env);
-  Expression libraryReference(ImportedLibrary imported, SchemeSymbol id);
-  Future<Expression> theme(SchemeSymbol theme, Frame env);
+  Future<Value> schemeImport(List<Value> args, Frame env);
+  Future<Value> schemeImportInline(Value id, Frame env);
+  Value libraryReference(ImportedLibrary imported, SchemeSymbol id);
+  Future<Value> theme(SchemeSymbol theme, Frame env);
   String colorToCss(Color color);
   void importAll(Frame __env) {
     addVariableBuiltin(__env, const SchemeSymbol("js"), (__exprs, __env) {
@@ -31,7 +31,8 @@ abstract class _$WebLibraryMixin {
     }, 0,
         maxArgs: -1,
         docs: Docs.variable("js",
-            "Evaluates a piece of JavaScript code and returns the result.\n\nCompatible types will automatically be converted between the languages.\n"));
+            "Evaluates a piece of JavaScript code and returns the result.\n\nCompatible types will automatically be converted between the languages.\n",
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("js-context"), (__exprs, __env) {
       return this.jsContext();
     }, 0,
@@ -41,50 +42,55 @@ abstract class _$WebLibraryMixin {
             [],
             returnType: "js object"));
     addBuiltin(__env, const SchemeSymbol("js-set!"), (__exprs, __env) {
-      if (__exprs[0] is! JsExpression)
+      if (__exprs[0] is! JsValue)
         throw SchemeException('Argument of invalid type passed to js-set!.');
       return this.jsSet(__exprs[0], __exprs[1], __exprs[2]);
     }, 3,
-        docs: Docs("js-set!", "Sets [property] of [obj] to be [value].\n", [
-          Param("js object", "obj"),
-          Param(null, "property"),
-          Param(null, "value")
-        ]));
+        docs: Docs(
+            "js-set!",
+            "Sets [property] of [obj] to be [value].\n",
+            [
+              Param("js object", "obj"),
+              Param("value", "property"),
+              Param("value", "value")
+            ],
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("js-ref"), (__exprs, __env) {
-      if (__exprs[0] is! JsExpression)
+      if (__exprs[0] is! JsValue)
         throw SchemeException('Argument of invalid type passed to js-ref.');
       return this.jsRef(__exprs[0], __exprs[1]);
     }, 2,
         docs: Docs("js-ref", "Returns [property] of [obj].\n",
-            [Param("js object", "obj"), Param(null, "property")]));
+            [Param("js object", "obj"), Param("value", "property")],
+            returnType: "value"));
     addVariableBuiltin(__env, const SchemeSymbol("js-call"), (__exprs, __env) {
       return this.jsCall(__exprs);
     }, 2,
         maxArgs: -1,
         docs: Docs.variable("js-call",
-            "Calls a method (second arg) on a JS object (first arg) with some args.\n"));
+            "Calls a method (second arg) on a JS object (first arg) with some args.\n",
+            returnType: "value"));
     addVariableBuiltin(__env, const SchemeSymbol("js-object"),
         (__exprs, __env) {
       return this.jsObject(__exprs);
     }, 0,
         maxArgs: -1,
         docs: Docs.variable("js-object",
-            "Constructs a new JS object of a type (first arg) with some arguments.\n"));
+            "Constructs a new JS object of a type (first arg) with some arguments.\n",
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("js-object?"), (__exprs, __env) {
       return Boolean(this.isJsObject(__exprs[0]));
     }, 1,
-        docs: Docs(
-            "js-object?",
-            "Returns true if [expression] is a JS object.\n",
-            [Param(null, "expression")],
+        docs: Docs("js-object?", "Returns true if [value] is a JS object.\n",
+            [Param("value", "value")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("js-procedure?"), (__exprs, __env) {
       return Boolean(this.isJsProcedure(__exprs[0]));
     }, 1,
         docs: Docs(
             "js-procedure?",
-            "Returns true if [expression] is a JS function.\n",
-            [Param(null, "expression")],
+            "Returns true if [value] is a JS function.\n",
+            [Param("value", "value")],
             returnType: "bool"));
     addBuiltin(__env, const SchemeSymbol("rgb"), (__exprs, __env) {
       if (__exprs[0] is! Integer ||
@@ -138,7 +144,7 @@ abstract class _$WebLibraryMixin {
             "For [theme], sets the color for [property] to be [color].\n", [
           Param(null, "theme"),
           Param("symbol", "property"),
-          Param(null, "color")
+          Param("value", "color")
         ]));
     addBuiltin(__env, const SchemeSymbol('theme-set-css!'), (__exprs, __env) {
       if (__exprs[0] is! Theme ||
@@ -165,29 +171,30 @@ abstract class _$WebLibraryMixin {
         docs: Docs('apply-theme', "Applies [theme] to the current interface.\n",
             [Param(null, "theme")]));
     addVariableBuiltin(__env, const SchemeSymbol('import'), (__exprs, __env) {
-      return AsyncExpression(this.schemeImport(__exprs, __env));
+      return AsyncValue(this.schemeImport(__exprs, __env));
     }, 0,
         maxArgs: -1,
         docs: Docs.variable('import',
             "Imports a library (first arg) as a module (returned asynchronously)\n\nRemaining args should be symbols in the library to be bound directly.\n"));
     addBuiltin(__env, const SchemeSymbol('import-inline'), (__exprs, __env) {
-      return AsyncExpression(this.schemeImportInline(__exprs[0], __env));
+      return AsyncValue(this.schemeImportInline(__exprs[0], __env));
     }, 1,
         docs: Docs(
             'import-inline',
             "Imports a library at [id] directly into the current environment.\n",
-            [Param(null, "id")]));
+            [Param("value", "id")]));
     addBuiltin(__env, const SchemeSymbol('lib-ref'), (__exprs, __env) {
       if (__exprs[0] is! ImportedLibrary || __exprs[1] is! SchemeSymbol)
         throw SchemeException('Argument of invalid type passed to lib-ref.');
       return this.libraryReference(__exprs[0], __exprs[1]);
     }, 2,
         docs: Docs('lib-ref', "References an [id] bound within [imported].\n",
-            [Param("library", "imported"), Param("symbol", "id")]));
+            [Param("library", "imported"), Param("symbol", "id")],
+            returnType: "value"));
     addBuiltin(__env, const SchemeSymbol("theme"), (__exprs, __env) {
       if (__exprs[0] is! SchemeSymbol)
         throw SchemeException('Argument of invalid type passed to theme.');
-      return AsyncExpression(this.theme(__exprs[0], __env));
+      return AsyncValue(this.theme(__exprs[0], __env));
     }, 1,
         docs: Docs("theme", "Loads and applies a [theme].\n",
             [Param("symbol", "theme")]));

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -101,7 +101,7 @@ class Repl {
     var tokens = tokenizeLines(code.split("\n")).toList();
     var loggingArea = activeLoggingArea;
     while (tokens.isNotEmpty) {
-      Expression result;
+      Value result;
       try {
         Expression expr = schemeRead(tokens, interpreter.impl);
         result = schemeEval(expr, interpreter.globalEnv);
@@ -188,8 +188,8 @@ class Repl {
     }
   }
 
-  logInto(Element element, Expression logging, [bool newline = true]) {
-    if (logging is AsyncExpression) {
+  logInto(Element element, Value logging, [bool newline = true]) {
+    if (logging is AsyncValue) {
       var box = SpanElement()
         ..text = '$logging\n'
         ..classes = ['repl-async'];


### PR DESCRIPTION
Previously, everything that could be touched by Scheme code was an `Expression`. However, many `Expression` subtypes can't actually be evaluated.

This refactor changes the base Scheme type to be a `Value`, with a limited subset of evaluate-able types remaining subclasses of `Expression` (which itself inherits from `Value`).

Additionally, instances of the `Pair` class are no longer directly iterable. Instead, whenever we want to guarantee that a `Pair` or the empty list is a Scheme list, we wrap it in `SchemeList`, which can be iterated over.

This also includes changes to the builder and other parts of the interpreter to support `Value` and `SchemeList`.

The impl library needs to change for this as well. I've made the changes and will put up a PR there soon. Until then, Travis will fail.

