### PR TITLE
Initial Implementation of Autocomplete

### DIFF
--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -127,7 +127,7 @@ class CodeInput {
     List output = ["", false];
     if (totalMissingCount != 0) {
       int strIndex = refLine.indexOf("(");
-      while (strIndex < (refLine.length - 1)) {
+      while (strIndex < refLine.length) {
         int nextClose = refLine.indexOf(")", strIndex + 1);
         int nextOpen = refLine.indexOf("(", strIndex + 1);
         // Find the open paren that corresponds to the missing closed paren
@@ -141,6 +141,8 @@ class CodeInput {
             if (symbol.length < currString.length) {
               output[1] = true;
             }
+          } else if (position > 1) {
+            output = _currOp(inputText, position - 1);
           }
           break;
         }
@@ -149,7 +151,6 @@ class CodeInput {
     }
     return output;
   }
-
 
   /// Determines how much space to indent the next line, based on parens
   int _countSpace(String inputText, int position) {
@@ -200,7 +201,8 @@ class CodeInput {
     List<String> matchingWords = [];
     int currLength = currWord.length;
     for (String schemeWord in wordToDocs.keys) {
-      if (((schemeWord.length > currWord.length) && !fullWord) || schemeWord.length == currWord.length) {
+      if (((schemeWord.length > currWord.length) && !fullWord) ||
+          schemeWord.length == currWord.length) {
         if (schemeWord.substring(0, currLength) == currWord) {
           matchingWords.add(schemeWord);
         }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -119,7 +119,7 @@ class CodeInput {
     bool multipleLines = false;
     String refLine;
     int totalMissingCount = 0;
-  
+
     for (refLine in splitLines.reversed) {
       totalMissingCount += countParens(refLine) ?? 0;
       // Find the first line with an open paren but no close paren
@@ -137,7 +137,8 @@ class CodeInput {
           totalMissingCount -= 1;
         } else if (nextOpen == -1 || nextClose == -1 || nextOpen < nextClose) {
           //Assuming the word is right after the parens
-          List splitRef = refLine.substring(strIndex + 1).split(RegExp("[ ()]+"));
+          List splitRef =
+              refLine.substring(strIndex + 1).split(RegExp("[ ()]+"));
           //Determine if op represents the full string
           return [splitRef[0], splitRef.length > 1 || multipleLines];
         }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -25,6 +25,7 @@ class CodeInput {
   Map<String, Docs> wordToDocs;
   bool _active = true;
   final List<StreamSubscription> _subs = [];
+  String tabComplete = "";
 
   Function(String code) runCode;
   Function(int parens) parenListener;
@@ -242,13 +243,16 @@ class CodeInput {
     _autoBox.classes = ["docs"];
     if (matchingWords.isEmpty) {
       //If there are no matching words, hide the autocomplete box
+      tabComplete = "";
       _autoBox.style.visibility = "hidden";
     } else if (matchingWords.length == 1) {
       //If there is only one matching word, display the docs for that word
       render(wordToDocs[matchingWords.first], _autoBox);
       _autoBox.style.visibility = "hidden";
       _autoBox.children.last.style.visibility = "visible";
+      tabComplete = matchingWords.first.substring(currLength);
     } else {
+      tabComplete = "";
       //Add each matching word as its own element for formatting purposes
       for (String match in matchingWords) {
         _autoBox.append(SpanElement()
@@ -276,6 +280,9 @@ class CodeInput {
       await highlight(saveCursor: true);
     } else if (key == KeyCode.TAB) {
       event.preventDefault();
+      int cursor = findPosition(element, window.getSelection().getRangeAt(0));
+      element.appendText(tabComplete);
+      await highlight(cursor: cursor + tabComplete.length + 1);
     }
   }
 }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -168,14 +168,21 @@ class CodeInput {
     return matchingWords;
   }
 
+  ///Finds the last words
   void _autocomplete() {
     List<String> inputText = element.text.split(RegExp("[ \n()]+"));
     String findMatch = inputText.last;
     List<String> matchingWords =
-        findMatch.isNotEmpty ? _wordMatches(inputText.last) : [];
+        findMatch.isNotEmpty ? _wordMatches(findMatch) : [];
     if (matchingWords.isEmpty) {
+      _autoBox.text = "";
       _autoBox.style.visibility = "hidden";
     } else {
+      String autoText = "";
+      for (String match in matchingWords) {
+        autoText += "$match          ";
+      }
+      _autoBox.text = autoText;
       _autoBox.style.visibility = "visible";
     }
   }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -19,6 +19,7 @@ class CodeInput {
   Element element;
   //Create an element that contains possible autcomplete options
   Element _autoBox;
+  Element _wrapperAutoBox;
   Map<String, Docs> wordToDocs;
   bool _active = true;
   final List<StreamSubscription> _subs = [];
@@ -33,14 +34,14 @@ class CodeInput {
     _autoBox = DivElement()
       ..classes = ["docs"]
       ..style.visibility = "hidden";
-    Element wrapperAutoBox = DivElement()
+    _wrapperAutoBox = DivElement()
       ..classes = ["render"]
       ..append(_autoBox);
     _subs.add(element.onKeyPress.listen(_onInputKeyPress));
     _subs.add(element.onKeyDown.listen(_keyListener));
     _subs.add(element.onKeyUp.listen(_keyListener));
     log.append(element);
-    log.append(wrapperAutoBox);
+    log.append(_wrapperAutoBox);
     element.focus();
     parenListener ??= (_) => null;
     parenListener(missingParens);
@@ -61,7 +62,7 @@ class CodeInput {
   void deactivate() {
     _active = false;
     element.contentEditable = 'false';
-    _autoBox.remove();
+    _wrapperAutoBox.remove();
     for (var sub in _subs) {
       sub.cancel();
     }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -18,14 +18,14 @@ class CodeInput {
   Element element;
   //Create an element that contains possible autcomplete options
   Element _autoBox;
-  Frame env;
+  Map<String, Docs> wordToDocs;
   bool _active = true;
   final List<StreamSubscription> _subs = [];
 
   Function(String code) runCode;
   Function(int parens) parenListener;
 
-  CodeInput(Element log, this.runCode, this.env, {this.parenListener}) {
+  CodeInput(Element log, this.runCode, Frame env, {this.parenListener}) {
     element = SpanElement()
       ..classes = ['code-input']
       ..contentEditable = 'true';
@@ -40,6 +40,7 @@ class CodeInput {
     element.focus();
     parenListener ??= (_) => null;
     parenListener(missingParens);
+    wordToDocs = allDocumentedForms(env);
   }
 
   String get text => element.text;
@@ -157,7 +158,7 @@ class CodeInput {
   List<String> _wordMatches(String currWord) {
     List<String> matchingWords = [];
     int currLength = currWord.length;
-    for (String schemeWord in allDocumentedForms(env).keys) {
+    for (String schemeWord in wordToDocs.keys) {
       if (schemeWord.length >= currWord.length) {
         if (schemeWord.substring(0, currLength) == currWord) {
           matchingWords.add(
@@ -187,13 +188,13 @@ class CodeInput {
       _autoBox.innerHtml = "";
       _autoBox.style.visibility = "hidden";
     } else {
+      //Add each matching word as its own element for formatting purposes
       _autoBox.children = [];
       for (String match in matchingWords) {
         _autoBox.append(SpanElement()
           ..classes = ["autobox-word"]
           ..innerHtml = match);
       }
-      // _autoBox.innerHtml = autoText;
       _autoBox.style.visibility = "visible";
     }
   }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -31,13 +31,16 @@ class CodeInput {
       ..classes = ['code-input']
       ..contentEditable = 'true';
     _autoBox = DivElement()
-      ..classes = ["autobox"]
+      ..classes = ["docs"]
       ..style.visibility = "hidden";
+    Element wrapperAutoBox = DivElement()
+      ..classes = ["render"]
+      ..append(_autoBox);
     _subs.add(element.onKeyPress.listen(_onInputKeyPress));
     _subs.add(element.onKeyDown.listen(_keyListener));
     _subs.add(element.onKeyUp.listen(_keyListener));
     log.append(element);
-    log.append(_autoBox);
+    log.append(wrapperAutoBox);
     element.focus();
     parenListener ??= (_) => null;
     parenListener(missingParens);
@@ -230,7 +233,7 @@ class CodeInput {
     }
     //Clear whatever is currently in the box
     _autoBox.children = [];
-    _autoBox.classes = ["autobox"];
+    _autoBox.classes = ["docs"];
     if (matchingWords.isEmpty) {
       //If there are no matching words, hide the autocomplete box
       _autoBox.style.visibility = "hidden";
@@ -263,6 +266,8 @@ class CodeInput {
       await delay(0);
       parenListener(missingParens);
       await highlight(saveCursor: true);
+    } else if (key == KeyCode.TAB) {
+      event.preventDefault();
     }
   }
 }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -161,7 +161,8 @@ class CodeInput {
     for (String schemeWord in autcompleteList) {
       if (schemeWord.length >= currWord.length) {
         if (schemeWord.substring(0, currLength) == currWord) {
-          matchingWords.add(schemeWord);
+          matchingWords.add(
+              "<strong>${schemeWord.substring(0, currLength)}</strong>${schemeWord.substring(currLength)}");
         }
       }
     }
@@ -170,6 +171,7 @@ class CodeInput {
 
   ///Finds and displays the possible words that the user may be typing
   void _autocomplete() {
+    //Find the text to the left of where the typing cursor currently is
     int cursorPos = findPosition(element, window.getSelection().getRangeAt(0));
     List<String> inputText =
         element.text.substring(0, cursorPos).split(RegExp("[()]+"));
@@ -183,7 +185,7 @@ class CodeInput {
     }
     if (matchingWords.isEmpty) {
       //If there are no matching words, hide the autocomplete box
-      _autoBox.text = "";
+      _autoBox.innerHtml = "";
       _autoBox.style.visibility = "hidden";
     } else {
       String autoText = "";
@@ -191,7 +193,7 @@ class CodeInput {
       for (String match in matchingWords) {
         autoText += " $match         ";
       }
-      _autoBox.text = autoText;
+      _autoBox.innerHtml = autoText;
       _autoBox.style.visibility = "visible";
     }
   }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -164,6 +164,9 @@ class CodeInput {
         if (schemeWord.substring(0, currLength) == currWord) {
           matchingWords.add(schemeWord);
         }
+      } else if (currWord.endsWith(" ") &&
+          schemeWord == currWord.substring(0, currWord.length - 1)) {
+        matchingWords.add(schemeWord);
       }
     }
     return matchingWords;
@@ -176,14 +179,12 @@ class CodeInput {
     List<String> inputText =
         element.text.substring(0, cursorPos).split(RegExp("[(]+"));
     List<String> matchingWords = [];
-    //Find the last word that was being typed, ignoring any empty strings
+    //Find the last word that was being typed
     int currLength = 0;
-    for (String findMatch in inputText.reversed) {
-      if (findMatch.isNotEmpty) {
-        matchingWords = _wordMatches(findMatch);
-        currLength = findMatch.length;
-        break;
-      }
+    String findMatch = inputText.last;
+    if (findMatch.isNotEmpty && inputText.length > 1) {
+      matchingWords = _wordMatches(findMatch);
+      currLength = findMatch.length;
     }
     //Clear whatever is currently in the box
     _autoBox.children = [];

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -15,6 +15,8 @@ const List<SchemeSymbol> noIndentForms = [
   SchemeSymbol("define-macro")
 ];
 
+bool _enableAutocomplete = false;
+
 class CodeInput {
   Element element;
   //Create an element that contains possible autcomplete options
@@ -67,6 +69,9 @@ class CodeInput {
       sub.cancel();
     }
   }
+
+  void enableAutocomplete() => _enableAutocomplete = true;
+  void disableAutocomplete() => _enableAutocomplete = false;
 
   Future highlight(
       {bool saveCursor = false, int cursor, bool atEnd = false}) async {
@@ -258,7 +263,9 @@ class CodeInput {
 
   _keyListener(KeyboardEvent event) async {
     int key = event.keyCode;
-    _autocomplete();
+    if (_enableAutocomplete) {
+      _autocomplete();
+    }
     if (key == KeyCode.BACKSPACE) {
       await delay(0);
       parenListener(missingParens);

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -16,6 +16,7 @@ const List<SchemeSymbol> noIndentForms = [
 
 class CodeInput {
   Element element;
+  Element autoBox;
   bool _active = true;
   final List<StreamSubscription> _subs = [];
 
@@ -26,10 +27,12 @@ class CodeInput {
     element = SpanElement()
       ..classes = ['code-input']
       ..contentEditable = 'true';
+    autoBox = DivElement()..classes = ["autoBox"];
     _subs.add(element.onKeyPress.listen(_onInputKeyPress));
     _subs.add(element.onKeyDown.listen(_keyListener));
     _subs.add(element.onKeyUp.listen(_keyListener));
     log.append(element);
+    log.append(autoBox);
     element.focus();
     parenListener ??= (_) => null;
     parenListener(missingParens);
@@ -49,6 +52,7 @@ class CodeInput {
   void deactivate() {
     _active = false;
     element.contentEditable = 'false';
+    autoBox.remove();
     for (var sub in _subs) {
       sub.cancel();
     }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -14,19 +14,18 @@ const List<SchemeSymbol> noIndentForms = [
   SchemeSymbol("define-macro")
 ];
 
-const List<String> autcompleteList = ["cons", "car", "cdr", "define"];
-
 class CodeInput {
   Element element;
   //Create an element that contains possible autcomplete options
   Element _autoBox;
+  Frame env;
   bool _active = true;
   final List<StreamSubscription> _subs = [];
 
   Function(String code) runCode;
   Function(int parens) parenListener;
 
-  CodeInput(Element log, this.runCode, {this.parenListener}) {
+  CodeInput(Element log, this.runCode, this.env, {this.parenListener}) {
     element = SpanElement()
       ..classes = ['code-input']
       ..contentEditable = 'true';
@@ -158,7 +157,7 @@ class CodeInput {
   List<String> _wordMatches(String currWord) {
     List<String> matchingWords = [];
     int currLength = currWord.length;
-    for (String schemeWord in autcompleteList) {
+    for (String schemeWord in allDocumentedForms(env).keys) {
       if (schemeWord.length >= currWord.length) {
         if (schemeWord.substring(0, currLength) == currWord) {
           matchingWords.add(
@@ -174,7 +173,7 @@ class CodeInput {
     //Find the text to the left of where the typing cursor currently is
     int cursorPos = findPosition(element, window.getSelection().getRangeAt(0));
     List<String> inputText =
-        element.text.substring(0, cursorPos).split(RegExp("[()]+"));
+        element.text.substring(0, cursorPos).split(RegExp("[(]+"));
     List<String> matchingWords = [];
     //Find the last word that was being typed, ignoring any empty strings
     for (String findMatch in inputText.reversed) {

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:html';
 
 import 'package:cs61a_scheme/cs61a_scheme.dart';
+import 'package:cs61a_scheme/cs61a_scheme_web.dart';
 
 import 'highlight.dart';
 
@@ -161,8 +162,7 @@ class CodeInput {
     for (String schemeWord in wordToDocs.keys) {
       if (schemeWord.length >= currWord.length) {
         if (schemeWord.substring(0, currLength) == currWord) {
-          matchingWords.add(
-              "<strong>${schemeWord.substring(0, currLength)}</strong>${schemeWord.substring(currLength)}");
+          matchingWords.add(schemeWord);
         }
       }
     }
@@ -177,23 +177,33 @@ class CodeInput {
         element.text.substring(0, cursorPos).split(RegExp("[(]+"));
     List<String> matchingWords = [];
     //Find the last word that was being typed, ignoring any empty strings
+    int currLength = 0;
     for (String findMatch in inputText.reversed) {
       if (findMatch.isNotEmpty) {
         matchingWords = _wordMatches(findMatch);
+        currLength = findMatch.length;
         break;
       }
     }
+    //Clear whatever is currently in the box
+    _autoBox.children = [];
+    _autoBox.classes = ["autobox"];
     if (matchingWords.isEmpty) {
       //If there are no matching words, hide the autocomplete box
-      _autoBox.innerHtml = "";
       _autoBox.style.visibility = "hidden";
+    } else if (matchingWords.length == 1) {
+      //If there is only one matching word, display the docs for that word
+      render(wordToDocs[matchingWords.first], _autoBox);
+      _autoBox.style.visibility = "hidden";
+      _autoBox.children.last.style.visibility = "visible";
     } else {
       //Add each matching word as its own element for formatting purposes
-      _autoBox.children = [];
       for (String match in matchingWords) {
         _autoBox.append(SpanElement()
           ..classes = ["autobox-word"]
-          ..innerHtml = match);
+          //Bold the matching characters
+          ..innerHtml =
+              "<strong>${match.substring(0, currLength)}</strong>${match.substring(currLength)}");
       }
       _autoBox.style.visibility = "visible";
     }

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -168,19 +168,28 @@ class CodeInput {
     return matchingWords;
   }
 
-  ///Finds the last words
+  ///Finds and displays the possible words that the user may be typing
   void _autocomplete() {
-    List<String> inputText = element.text.split(RegExp("[ \n()]+"));
-    String findMatch = inputText.last;
-    List<String> matchingWords =
-        findMatch.isNotEmpty ? _wordMatches(findMatch) : [];
+    int cursorPos = findPosition(element, window.getSelection().getRangeAt(0));
+    List<String> inputText =
+        element.text.substring(0, cursorPos).split(RegExp("[()]+"));
+    List<String> matchingWords = [];
+    //Find the last word that was being typed, ignoring any empty strings
+    for (String findMatch in inputText.reversed) {
+      if (findMatch.isNotEmpty) {
+        matchingWords = _wordMatches(findMatch);
+        break;
+      }
+    }
     if (matchingWords.isEmpty) {
+      //If there are no matching words, hide the autocomplete box
       _autoBox.text = "";
       _autoBox.style.visibility = "hidden";
     } else {
       String autoText = "";
+      //TODO: Improve the formatting here
       for (String match in matchingWords) {
-        autoText += "$match          ";
+        autoText += " $match         ";
       }
       _autoBox.text = autoText;
       _autoBox.style.visibility = "visible";

--- a/lib/src/web_ui/code_input.dart
+++ b/lib/src/web_ui/code_input.dart
@@ -30,7 +30,7 @@ class CodeInput {
       ..classes = ['code-input']
       ..contentEditable = 'true';
     _autoBox = DivElement()
-      ..classes = ["autoBox"]
+      ..classes = ["autobox"]
       ..style.visibility = "hidden";
     _subs.add(element.onKeyPress.listen(_onInputKeyPress));
     _subs.add(element.onKeyDown.listen(_keyListener));
@@ -187,12 +187,13 @@ class CodeInput {
       _autoBox.innerHtml = "";
       _autoBox.style.visibility = "hidden";
     } else {
-      String autoText = "";
-      //TODO: Improve the formatting here
+      _autoBox.children = [];
       for (String match in matchingWords) {
-        autoText += " $match         ";
+        _autoBox.append(SpanElement()
+          ..classes = ["autobox-word"]
+          ..innerHtml = match);
       }
-      _autoBox.innerHtml = autoText;
+      // _autoBox.innerHtml = autoText;
       _autoBox.style.visibility = "visible";
     }
   }

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -90,8 +90,8 @@ class Repl {
       ..text = prompt
       ..classes = ['repl-prompt'];
     container.append(activePrompt);
-    activeInput =
-        CodeInput(container, runCode, parenListener: updateParenStatus);
+    activeInput = CodeInput(container, runCode, interpreter.globalEnv,
+        parenListener: updateParenStatus);
     container.scrollTop = container.scrollHeight;
   }
 

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -21,7 +21,6 @@ class Repl {
   int historyIndex = -1;
 
   final String prompt;
-
   Repl(this.interpreter, Element parent, {this.prompt = 'scm> '}) {
     if (window.localStorage.containsKey('#repl-history')) {
       var decoded = json.decode(window.localStorage['#repl-history']);
@@ -77,6 +76,17 @@ class Repl {
     addBuiltin(env, const SchemeSymbol('disable-autodraw'), (_a, _b) {
       logText('Autodraw disabled\n');
       autodraw = false;
+      return undefined;
+    }, 0);
+    addBuiltin(env, const SchemeSymbol('autocomplete'), (_a, _b) {
+      logText('While typing, will display a list of possible procedures.\n'
+          '(disable-autocomplete) to disable\n');
+      activeInput.enableAutocomplete();
+      return undefined;
+    }, 0);
+    addBuiltin(env, const SchemeSymbol('disable-autocomplete'), (_a, _b) {
+      logText('Autocomplete disabled\n');
+      activeInput.disableAutocomplete();
       return undefined;
     }, 0);
   }

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -37,6 +37,12 @@ class Repl {
     status = SpanElement()..classes = ['repl-status'];
     container.append(status);
     buildNewInput();
+    if (window.localStorage.containsKey('autocomplete')) {
+      String val = window.localStorage['autocomplete'];
+      if (val == 't') {
+        activeInput.enableAutocomplete();
+      }
+    }
     interpreter.logger = (logging, [newline = true]) {
       var box = SpanElement();
       activeLoggingArea.append(box);
@@ -82,11 +88,13 @@ class Repl {
       logText('While typing, will display a list of possible procedures.\n'
           '(disable-autocomplete) to disable\n');
       activeInput.enableAutocomplete();
+      window.localStorage['autocomplete'] = 't';
       return undefined;
     }, 0);
     addBuiltin(env, const SchemeSymbol('disable-autocomplete'), (_a, _b) {
       logText('Autocomplete disabled\n');
       activeInput.disableAutocomplete();
+      window.localStorage['autocomplte'] = 'f';
       return undefined;
     }, 0);
   }

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -94,7 +94,7 @@ class Repl {
     addBuiltin(env, const SchemeSymbol('disable-autocomplete'), (_a, _b) {
       logText('Autocomplete disabled\n');
       activeInput.disableAutocomplete();
-      window.localStorage['autocomplte'] = 'f';
+      window.localStorage['autocomplete'] = 'f';
       return undefined;
     }, 0);
   }

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -102,9 +102,11 @@ body {
 }
 
 .autobox {
-  min-height: 40px;
-  width: 80ch;
+  min-height: 80px;
+  width: 72ch;
   padding: 5px;
+  margin: 0.5em;
+  border-radius: 0.185em;
   @include other-frame;
 }
 

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -101,6 +101,11 @@ body {
   }
 }
 
+.autoBox {
+  height: 40px;
+  @include other-frame;
+}
+
 .code-input {
   display: inline-block;
 }

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -101,15 +101,6 @@ body {
   }
 }
 
-.autobox {
-  min-height: 80px;
-  width: 72ch;
-  padding: 5px;
-  margin: 0.5em;
-  border-radius: 0.185em;
-  @include other-frame;
-}
-
 .autobox-word {
   margin: 10px;
   display: inline-block;

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -111,7 +111,6 @@ body {
 .autobox-word {
   margin: 10px;
   display: inline-block;
-  @include other-frame;
 }
 
 .code-input {

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -101,8 +101,16 @@ body {
   }
 }
 
-.autoBox {
-  height: 40px;
+.autobox {
+  min-height: 40px;
+  width: 80ch;
+  padding: 5px;
+  @include other-frame;
+}
+
+.autobox-word {
+  margin: 10px;
+  display: inline-block;
   @include other-frame;
 }
 


### PR DESCRIPTION
Closes #74 

Initially the autocomplete feature is off until it is toggled with (autocomplete) but the window should save whether autocomplete was toggled so students won't have to keep enabling/disabling it.

The way I intended for this to work was for words to be displayed that the user could be typing. Once there is only one possible word left, the docs for that procedure is displayed. Also, for longer words, you can press tab to autocomplete the word that was being typed.

There are some things that can definitely be improved from this point. One thing is to maybe make the matching more sophisticated (right now I only match the prefixes of the word that is being typed with the possible words that can be displayed). Another thing is for something like define to not have the autocomplete box disappear when typing the function name and arguments.