### PR TITLE
Shows pair diagrams on mouse-over of log

### DIFF
--- a/lib/src/web/renderer.dart
+++ b/lib/src/web/renderer.dart
@@ -11,8 +11,10 @@ import '../web_ui/highlight.dart';
 
 import 'web_library.dart';
 
-void render(Widget widget, Element container) {
-  _Renderer(container, context['jsPlumb']).render(widget);
+Function render(Widget widget, Element container) {
+  var renderer = _Renderer(container, context['jsPlumb']);
+  renderer.render(widget);
+  return () => renderer.refreshConnections();
 }
 
 class _Renderer {

--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -218,6 +218,21 @@ class Repl {
         logInto(box, expr is Undefined ? null : expr);
         return null;
       });
+    } else if (logging is Pair && !autodraw) {
+      var pairBox = SpanElement()..classes = ['mouseover-wrapper'];
+      pairBox.text = logging.toString() + (newline ? '\n' : '');
+      var diagram = Diagram(logging);
+      var diagramBox = SpanElement();
+      var refresher = render(diagram, diagramBox);
+      pairBox.append(diagramBox);
+      element.append(pairBox);
+      pairBox.onMouseOver.listen((e) {
+        refresher();
+      });
+      pairBox.onClick.listen((e) {
+        pairBox.classes = [];
+        refresher();
+      });
     } else if (logging == null) {
       element.text = '';
     } else if (logging is Widget) {

--- a/lib/styles/_diagram.scss
+++ b/lib/styles/_diagram.scss
@@ -1,7 +1,7 @@
 @import 'theme';
 
 .render {
-  
+
   @include render;
 
   .markdown {
@@ -34,7 +34,7 @@
     @include button;
     @include button-text;
   }
-  
+
   .block {
     display: inline-block;
     padding: 0.3em;
@@ -42,7 +42,7 @@
     height: 1.9em;
     vertical-align: middle;
     text-align: center;
-    
+
     .strike {
       display: inline-block;
       position: relative;
@@ -50,27 +50,27 @@
       transform: rotate(-45deg) scaleX(8);
     }
   }
-  
+
   svg path, svg circle {
     @include arrow;
   }
-  
+
   svg *[fill="transparent"] {
     fill: transparent;
   }
-  
+
   svg *[stroke="transparent"] {
     stroke: transparent;
   }
-  
+
   svg *[fill="none"] {
     fill: none;
   }
-  
+
   svg *[stroke="none"] {
     stroke: none;
   }
-  
+
   .pair {
     @include pair;
   }
@@ -88,11 +88,11 @@
     border-radius: 1.25em;
     @include async-block;
   }
-  
+
   .block-grid{
     margin: 0.5em;
     display: inline-block;
-    
+
     .block:not(:first-child) {
       border-left: none;
     }
@@ -166,16 +166,17 @@
 
     .frames{
       vertical-align: top;
-      
+
       %frame {
         padding: 0.375em;
         margin: 0.5em;
+        margin-right: 3.63em;
         border-radius: 0.185em;
-        
+
         .binding{
           margin-top: 0.125em;
         }
-        
+
         .align-right{
           float: right;
           border-bottom: 0.125em solid #fff;
@@ -183,33 +184,32 @@
           padding-left: 0.125em;
           @include binding-box;
         }
-        
+
         .parent{
           float: right;
           font-size: 75%;
         }
-        
+
         .return{
           @include return-value;
         }
       }
-      
+
       .current-frame {
         @extend %frame;
         @include current-frame;
       }
-      
+
       .other-frame {
         @extend %frame;
         @include other-frame;
       }
-      
+
     }
-    
+
     .objects{
       vertical-align: top;
       padding: 0.375em;
-      padding-left: 3.13em;
       padding-top: 1em;
       line-height: 2.0em;
     }

--- a/web/assets/style.scss
+++ b/web/assets/style.scss
@@ -59,7 +59,7 @@ body {
   white-space: pre-wrap;
   word-wrap: break-word;
   overflow-y:auto;
-  
+
   @include background;
   @include text;
 
@@ -83,14 +83,14 @@ body {
     font-size: 80%;
     @include status;
   }
-  
+
   .render {
     position: relative;
     margin: 0;
     padding: 0;
     display: block;
   }
-  
+
   .render td {
     margin: 0;
     padding: 0;
@@ -98,6 +98,25 @@ body {
 
   .error {
     @include error;
+  }
+
+  .mouseover-wrapper {
+    .render {
+      display: none;
+    }
+    .objects {
+      padding: 0;
+    }
+    &:hover {
+      .render {
+        z-index: 1000;
+        border-radius: 0.185em;
+        position: absolute;
+        width: auto;
+        display: block;
+        @include other-frame;
+      }
+    }
   }
 }
 
@@ -109,7 +128,7 @@ body {
 .code-input {
   display: inline-block;
 }
-  
+
 .code-input:focus {
   outline: none;
 }

--- a/web/main.dart
+++ b/web/main.dart
@@ -12,8 +12,10 @@ const String motd = "**61A Scheme Web Interpreter**"
     """</small>
 --------------------------------------------------------------------------------
 **Diagramming**
-`(draw some-pair)` to create a box-and-pointer diagram [Try It](:try-draw)
-`(autodraw)` to start drawing diagrams for any returned list [Try It](:try-ad)
+Hover over any list to see its box-and-pointer diagram. Click to keep it.
+`(draw some-pair)` to draw a diagram directly [Try It](:try-draw)
+`(autodraw)` to display the diagram automatically [Try It](:try-ad)
+
 `(visualize some-code)` to create an environment diagram [Try It](:try-viz)
 
 **Other Useful Commands**


### PR DESCRIPTION
Resolves #20.

Normal log output:
![Screenshot 2019-03-25 at 11 39 13 PM](https://user-images.githubusercontent.com/1817677/54976420-86926180-4f57-11e9-8262-382ed3ee74b6.png)

If you hover over the logged output, the diagram will appear:
![Screenshot 2019-03-25 at 11 39 21 PM](https://user-images.githubusercontent.com/1817677/54976435-93af5080-4f57-11e9-9983-5577e735a05d.png)

Click on the output or the diagram to embed it persistently in the log:
![Screenshot 2019-03-25 at 11 39 31 PM](https://user-images.githubusercontent.com/1817677/54976488-bf323b00-4f57-11e9-8522-4ddf28e36285.png)


This is disabled when autodraw is enabled, since the diagrams will already be logged.