### PR TITLE
Removing dotted lists from cons, set-cdr, and streams

### DIFF
--- a/lib/src/core/expressions.dart
+++ b/lib/src/core/expressions.dart
@@ -100,6 +100,9 @@ abstract class PairOrEmpty extends Expression {
   /// Returns true iff this is a well-formed Scheme list.
   bool get wellFormed;
 
+  /// Returns true iff this pair is permitted in the CS61A version of Scheme.
+  bool get allowedForm;
+
   /// See [wellFormed].
   @deprecated
   bool isWellFormedList() => wellFormed;
@@ -112,6 +115,7 @@ class _EmptyList extends Expression implements PairOrEmpty {
   const _EmptyList();
   bool get inlineInDiagram => true;
   bool get wellFormed => true;
+  bool get allowedForm => true;
   @deprecated
   bool isWellFormedList() => true;
   bool get isNil => true;
@@ -141,6 +145,12 @@ class Pair<A extends Value, B extends Value> extends Expression
   /// This is a well-formed list if [second] is also a well-formed list.
   bool get wellFormed =>
       second is PairOrEmpty && (second as PairOrEmpty).wellFormed;
+
+  /// This is allowed in our version of scheme if [second] is a well-formed list or a [Promise].
+  bool get allowedForm =>
+      second is Promise ||
+      (second is PairOrEmpty && (second as PairOrEmpty).allowedForm);
+
   @deprecated
   bool isWellFormedList() => wellFormed;
 

--- a/lib/src/core/interpreter.dart
+++ b/lib/src/core/interpreter.dart
@@ -103,6 +103,7 @@ class Interpreter {
     const SchemeSymbol('set!'): doSetForm,
     const SchemeSymbol('quasiquote'): doQuasiquoteForm,
     const SchemeSymbol('unquote'): doUnquoteForm,
-    const SchemeSymbol('unquote-splicing'): doUnquoteForm
+    const SchemeSymbol('unquote-splicing'): doUnquoteForm,
+    const SchemeSymbol('variadic'): doVariadicForm
   };
 }

--- a/lib/src/core/special_forms.dart
+++ b/lib/src/core/special_forms.dart
@@ -132,3 +132,7 @@ Pair<Value, Boolean> quasiquoteItem(Value v, Frame env, [int level = 1]) {
 Value doUnquoteForm(SchemeList<Expression> expressions, Frame env) {
   throw SchemeException("Unquote outside of quasiquote");
 }
+
+Value doVariadicForm(SchemeList<Expression> expressions, Frame env) {
+  throw SchemeException("Variadic used outside of formals list");
+}

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -269,7 +269,7 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   @TriggerEventAfter(const SchemeSymbol("pair-mutation"))
   void setCdr(Pair pair, Value val) {
     // Added if statement to disallow malformed lists
-    if (!(val is PairOrEmpty && (val.wellFormed))) {
+    if (!(val is PairOrEmpty && val.wellFormed)) {
       throw SchemeException("cdr must be another pair or nil");
     }
     pair.second = val;

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -113,7 +113,14 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   Value cdr(Pair val) => val.second;
 
   /// Constructs a pair from values [car] and [cdr].
-  Pair cons(Value car, Value cdr) => Pair(car, cdr);
+  Pair cons(Value car, Value cdr) {
+    // Added if statement to disallow malformed lists
+    if (!(cdr is PairOrEmpty &&
+        (cdr.wellFormed || cdr.pair.second is Promise))) {
+      throw SchemeException("cdr must be another pair or nil");
+    }
+    return Pair(car, cdr);
+  }
 
   /// Finds the length of a well-formed Scheme list.
   num length(PairOrEmpty lst) => lst.lengthOrCycle;
@@ -262,6 +269,10 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   @SchemeSymbol("set-cdr!")
   @TriggerEventAfter(const SchemeSymbol("pair-mutation"))
   void setCdr(Pair pair, Value val) {
+    // Added if statement to disallow malformed lists
+    if (!(val is PairOrEmpty && (val.wellFormed))) {
+      throw SchemeException("cdr must be another pair or nil");
+    }
     pair.second = val;
   }
 

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -115,8 +115,7 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   /// Constructs a pair from values [car] and [cdr].
   Pair cons(Value car, Value cdr) {
     // Added if statement to disallow malformed lists
-    if (!(cdr is PairOrEmpty &&
-        (cdr.wellFormed || cdr.pair.second is Promise))) {
+    if (!(cdr is PairOrEmpty && cdr.wellFormed)) {
       throw SchemeException("cdr must be another pair or nil");
     }
     return Pair(car, cdr);

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -116,7 +116,7 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   Pair cons(Value car, Value cdr) {
     // Added if statement to disallow malformed lists
     if (!(cdr is PairOrEmpty && cdr.wellFormed)) {
-      throw SchemeException("cdr must be another pair or nil");
+      throw SchemeException("The cdr of a list must be another pair or nil");
     }
     return Pair(car, cdr);
   }
@@ -270,7 +270,7 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   void setCdr(Pair pair, Value val) {
     // Added if statement to disallow malformed lists
     if (!(val is PairOrEmpty && val.wellFormed)) {
-      throw SchemeException("cdr must be another pair or nil");
+      throw SchemeException("The cdr of a list must be another pair or nil");
     }
     pair.second = val;
   }

--- a/lib/src/core/standard_library.dart
+++ b/lib/src/core/standard_library.dart
@@ -115,7 +115,7 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   /// Constructs a pair from values [car] and [cdr].
   Pair cons(Value car, Value cdr) {
     // Added if statement to disallow malformed lists
-    if (!(cdr is PairOrEmpty && cdr.wellFormed)) {
+    if (!((cdr is PairOrEmpty && cdr.allowedForm) || cdr is Promise)) {
       throw SchemeException("The cdr of a list must be another pair or nil");
     }
     return Pair(car, cdr);
@@ -269,7 +269,7 @@ class StandardLibrary extends SchemeLibrary with _$StandardLibraryMixin {
   @TriggerEventAfter(const SchemeSymbol("pair-mutation"))
   void setCdr(Pair pair, Value val) {
     // Added if statement to disallow malformed lists
-    if (!(val is PairOrEmpty && val.wellFormed)) {
+    if (!((val is PairOrEmpty && val.allowedForm) || val is Promise)) {
       throw SchemeException("The cdr of a list must be another pair or nil");
     }
     pair.second = val;

--- a/lib/src/core/values.dart
+++ b/lib/src/core/values.dart
@@ -114,6 +114,11 @@ class Promise extends Value {
   Expression force() {
     if (!_evaluated) {
       expr = schemeEval(expr, env);
+      // Added to disallow malformed lists/streams
+      if (!(expr is PairOrEmpty &&
+          ((expr as PairOrEmpty).wellFormed || expr.pair.second is Promise))) {
+        throw SchemeException("A promise must contain a pair or nil");
+      }
       _evaluated = true;
     }
     return expr;

--- a/lib/src/core/values.dart
+++ b/lib/src/core/values.dart
@@ -117,7 +117,7 @@ class Promise extends Value {
       // Added to disallow malformed lists/streams
       if (!(expr is PairOrEmpty &&
           ((expr as PairOrEmpty).wellFormed || expr.pair.second is Promise))) {
-        throw SchemeException("A promise must contain a pair or nil");
+        throw SchemeException("A promise must contain a pair, stream, or nil");
       }
       _evaluated = true;
     }

--- a/lib/src/core/values.dart
+++ b/lib/src/core/values.dart
@@ -115,8 +115,7 @@ class Promise extends Value {
     if (!_evaluated) {
       expr = schemeEval(expr, env);
       // Added to disallow malformed lists/streams
-      if (!(expr is PairOrEmpty &&
-          ((expr as PairOrEmpty).wellFormed || expr.pair.second is Promise))) {
+      if (!(expr is PairOrEmpty && (expr as PairOrEmpty).allowedForm)) {
         throw SchemeException("A promise must contain a pair, stream, or nil");
       }
       _evaluated = true;

--- a/test/tests.scm
+++ b/test/tests.scm
@@ -250,15 +250,29 @@ circumference
   (= (* (numer x) (denom y))
      (* (numer y) (denom x))))
 
+;;; Modified test to error because dotted lists no longer allowed
 (define x (cons 1 2))
 (car x)
-; expect 1
+; expect Error
 
-(cdr x)
-; expect 2
+;;; Old version of test with dotted lists
+;;; (cdr x)
+;;; expect 2
 
-(define x (cons 1 2))
-(define y (cons 3 4))
+
+;;; Old version of test with dotted lists
+;;;(define x (cons 1 2))
+;;; expect Error
+;;;(define y (cons 3 4))
+;;;(define z (cons x y))
+;;;(car (car z))
+;;;; expect 1
+;;; z
+;;; expect ((1 . 2) 3 . 4)
+
+;;; New version of test without dotted lists
+(define x (cons 1 nil))
+(define y (cons 3 nil))
 (define z (cons x y))
 (car (car z))
 ; expect 1
@@ -267,11 +281,17 @@ circumference
 ; expect 3
 
 z
-; expect ((1 . 2) 3 . 4)
+;expect ((1) 3)
 
-(define (make-rat n d) (cons n d))
+;;; Old version of test with dotted lists
+;;;(define (make-rat n d) (cons n d))
+;;;(define (numer x) (car x))
+;;;(define (denom x) (cdr x))
+
+;;; New version of test without dotted lists
+(define (make-rat n d) (cons n (cons d nil)))
 (define (numer x) (car x))
-(define (denom x) (cdr x))
+(define (denom x) (car (cdr x)))
 (define (print-rat x)
   (display (numer x))
   (display '/)
@@ -295,9 +315,16 @@ z
   (if (= b 0)
       a
       (gcd b (remainder a b))))
+
+;;; Old version of test with dotted lists
+;;; (define (make-rat n d)
+;;;  (let ((g (gcd n d)))
+;;;    (cons (/ n g) (/ d g))))
+
+;;; New version of test without dotted lists
 (define (make-rat n d)
-  (let ((g (gcd n d)))
-    (cons (/ n g) (/ d g))))
+     (let ((g (gcd n d)))
+       (cons (/ n g) (cons (/ d g) nil))))
 (print-rat (add-rat one-third one-third))
 ; expect 2/3
 


### PR DESCRIPTION
I made changes based on [this document](https://docs.google.com/document/d/1LnpnNY8hr_XmbAMvxFGuSjKjF4M2wvWO1SA1TFlKRpA/edit?usp=sharing)

Cons and set-cdr only allow cdr to be a well formed pair or nil
![example_cons](https://user-images.githubusercontent.com/35640174/55273105-b2795400-5283-11e9-9945-70a06e61c50a.png)

Promises now, when forced, will error if it does not contain a well formed list, stream, or nil
![example_promise](https://user-images.githubusercontent.com/35640174/55273107-b60cdb00-5283-11e9-8403-27c9ae14bda5.png)

Because of the change to promises, streams now work like this
![example-stream](https://user-images.githubusercontent.com/35640174/55273109-b907cb80-5283-11e9-9523-ff5c5d80901a.PNG)

~~I want to take a little bit more time to take a look at removing the dot when someone inputs something like '(1 2 3 . 4) and with variadic functions since I want to make sure I'm not breaking something unintentionally.~~

Nevermind, I made these changes but not sure if there is a better way to do it.