### PR TITLE
Fix behavior when promise result is invalid

### DIFF
--- a/lib/src/core/logging.dart
+++ b/lib/src/core/logging.dart
@@ -50,7 +50,8 @@ class SchemeException extends Value implements Exception {
     if (!showTrace || callStack.isEmpty) return 'Error: $message';
     var str = 'Traceback (most recent call last)\n';
     for (int i = 0; i < callStack.length; i++) {
-      str += '$i\t${callStack[i]}\n';
+      var space = " " * (6 - i.toString().length);
+      str += '$i$space${callStack[i]}\n';
     }
     return str + 'Error: $message';
   }

--- a/lib/src/core/values.dart
+++ b/lib/src/core/values.dart
@@ -113,8 +113,7 @@ class Promise extends Value {
   /// Evaluates the promise, or returns the result if already evaluated.
   Expression force() {
     if (!_evaluated) {
-      expr = schemeEval(expr, env);
-      env.interpreter.language.validateCdr(expr,
+      expr = env.interpreter.language.validateCdr(schemeEval(expr, env),
           errorMessage: "A promise must contain a pair, stream, or nil");
       _evaluated = true;
     }

--- a/test/scm_test.dart
+++ b/test/scm_test.dart
@@ -44,15 +44,15 @@ String runSchemeTests() {
           print("For Input:");
           print(run.join('\n'));
           print("Expected error");
-          print("Actual:   ${formatActual(actual)}");
+          print("Actual:   ${formatTestOutput(actual)}");
           print("");
           failedCount++;
         }
       } else if (!logsEqual(actual, expected)) {
         print("For Input:");
         print(run.join('\n'));
-        print("Expected: ${line.substring(9)}");
-        print("Actual:   ${formatActual(actual)}");
+        print("Expected: ${formatTestOutput(expected)}");
+        print("Actual:   ${formatTestOutput(actual)}");
         print("");
         failedCount++;
       }
@@ -88,9 +88,9 @@ String runSchemeTests() {
   }
 }
 
-formatActual(actual) {
-  if (actual.length == 1) return actual[0];
-  return '\n' + actual.join('\n');
+formatTestOutput(List<String> output) {
+  if (output.length == 1) return output[0];
+  return '\n' + output.join('\n');
 }
 
 logsEqual(actual, expected) {

--- a/test/tests.scm
+++ b/test/tests.scm
@@ -804,6 +804,12 @@ b
 (prefix primes 10)
 ; expect (2 3 5 7 11 13 17 19 23 29)
 
+(define promise (delay (begin (print 2) 0)))
+(force promise)
+; expect 2;Traceback (most recent call last);0     (force promise);Error: A promise must contain a pair, stream, or nil
+(force promise)
+; expect 2;Traceback (most recent call last);0     (force promise);Error: A promise must contain a pair, stream, or nil
+
 ;;;;;;;;;;;;;;
 ;;;; Logic ;;;
 ;;;;;;;;;;;;;;


### PR DESCRIPTION
Fixes #91.

Also tweaks the error traceback formatting and tests.scm runner to allow for a test for this to be added.