### PR TITLE
Fix autofocus to allow for selection in log

### DIFF
--- a/lib/src/web_ui/repl.dart
+++ b/lib/src/web_ui/repl.dart
@@ -29,7 +29,9 @@ class Repl {
     addBuiltins();
     container = PreElement()..classes = ['repl'];
     container.onClick.listen((e) async {
-      if (!activeInput.element.contains(document.activeElement)) {
+      await delay(100);
+      if (window.getSelection().rangeCount == 0 ||
+          window.getSelection().getRangeAt(0).collapsed) {
         activeInput.element.focus();
       }
     });


### PR DESCRIPTION
Fixes #53.

Keep forgetting to fix this. Problem was the code that automatically focused the current input field was overly aggressive. It now waits 100ms after a click and checks to make sure nothing is selected before focusing.